### PR TITLE
examples in README should also use v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kayvee
 --
-    import "gopkg.in/clever/kayvee-go.v0"
+    import "gopkg.in/clever/kayvee-go.v1"
 
 Package kayvee provides methods to output human and machine parseable strings,
 with a "key=val" format.
@@ -13,7 +13,7 @@ Here's an example program that outputs a kayvee formatted string:
 
     import(
       "fmt"
-      "gopkg.in/Clever/kayvee-go.v0"
+      "gopkg.in/Clever/kayvee-go.v1"
     )
 
     func main() {


### PR DESCRIPTION
Copy-pasted from the README into my code, so didn't realize was using an older version than what we have available right now. Updating README to make it easier for future.