### PR TITLE
Log error converting to json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-PKG := gopkg.in/clever/kayvee-go.v0
+PKG := github.com/Clever/kayvee-go
 SUBPKG_NAMES :=
 SUBPKGS = $(addprefix $(PKG)/, $(SUBPKG_NAMES))
 PKGS = $(PKG) $(SUBPKGS)

--- a/kayvee.go
+++ b/kayvee.go
@@ -2,6 +2,7 @@ package kayvee
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // Log Levels:
@@ -19,7 +20,10 @@ const (
 
 // Format converts a map to a string of space-delimited key=val pairs
 func Format(data map[string]interface{}) string {
-	formattedString, _ := json.Marshal(data)
+	formattedString, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("Error converting kayvee message to json %s", err.Error())
+	}
 	return string(formattedString)
 }
 

--- a/kayvee.go
+++ b/kayvee.go
@@ -2,7 +2,7 @@ package kayvee
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
 )
 
 // Log Levels:
@@ -22,7 +22,8 @@ const (
 func Format(data map[string]interface{}) string {
 	formattedString, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("Error converting kayvee message to json %s", err.Error())
+		log.Printf("Error converting kayvee message to json: %s", err.Error())
+		return ""
 	}
 	return string(formattedString)
 }

--- a/kayvee_test.go
+++ b/kayvee_test.go
@@ -3,9 +3,10 @@ package kayvee
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Tests struct {
@@ -57,12 +58,37 @@ func Test_KayveeSpecs(t *testing.T) {
 
 		// Ensure correct type is passed to FormatLog, even if value undefined in tests.json
 		source, _ := spec.Input["source"].(string)
-		level, _ := spec.Input["level"].(string)
+		levelStr, _ := spec.Input["level"].(string)
+		level := convertToLogLevel(levelStr)
 		title, _ := spec.Input["title"].(string)
 		data, _ := spec.Input["data"].(map[string]interface{})
 		actual := FormatLog(source, level, title, data)
 
 		compareJSONStrings(t, expected, actual)
 	}
+}
 
+func convertToLogLevel(level string) LogLevel {
+	if level == "critical" {
+		return Critical
+	} else if level == "error" {
+		return Error
+	} else if level == "warning" {
+		return Warning
+	} else if level == "info" {
+		return Info
+	} else if level == "trace" {
+		return Trace
+	} else if level == "unknown" {
+		return Unknown
+	} else {
+		return ""
+	}
+}
+
+func TestMarshalErrors(t *testing.T) {
+	noMarshal := func() {}
+	resp := Format(map[string]interface{}{"test": noMarshal})
+	// Since it's not easy to test that we logged something here I'm just checked manually for now
+	assert.Equal(t, "", resp)
 }


### PR DESCRIPTION
I was accidentally passing a function into kayvee instead of a the values from
that function and it took me a second to figure out what was going because it was
failing silently. I wasn't sure what the best fix was. I didn't want to change the interface
and thought panicking was a bit extreme, so I just decided to log something so that
it was easier to debug.

Also, I noticed that we were running tests against an old version of kayvee, so I
changed that and updated the tests as necessary.
