### PR TITLE
update readme and prepare for v2.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,13 +1,12 @@
-image: bradrydzewski/go:1.4
+image: clever/drone-go:1.5
 script:
   - make test
 notify:
   email:
     recipients:
       - drone@clever.com
-  hipchat:
-    room: Clever-Dev-CI
-    token: {{hipchatToken}}
-    on_started: true
-    on_success: true
+  slack:
     on_failure: true
+    on_started: false
+    on_success: false
+    webhook_url: $$slack_webhook

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # kayvee
 --
-    import "gopkg.in/clever/kayvee-go.v2"
+    import "gopkg.in/clever/kayvee-go.v2.1"
 
 Package kayvee provides methods to output human and machine parseable strings,
-with a "key=val" format.
+with a "json" format.
+
+## [Logger Documentation](./logger)
 
 ## Example
 
@@ -27,7 +29,8 @@ Run `make test` to execute the tests
 
 ## Change log
 
-v0.0.1 - Initial release.
+v2.1 - Add kayvee-go/logger with log level, counters, and gauge support
+v0.1 - Initial release.
 
 ## Usage
 


### PR DESCRIPTION
Why: Changes were made to v2 to add logger support and then further add GaugeInt and GaugeFloat. 

What: Update the readme to add the new version to the changelog and link to the logger readme from the main one. 

* Use go 1.5
* Fix .drone.yml to use the slack notification