### PR TITLE
add constructor for logger w/ constant metadata

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -217,7 +217,14 @@ func (l *Logger) logWithLevel(logLvl LogLevel, data map[string]interface{}) {
 
 // New creates a *logger.Logger. Default values are Debug LogLevel, kayvee Formatter, and std.err output.
 func New(source string) *Logger {
-	logObj := Logger{}
+	return NewWithContext(source, nil)
+}
+
+// NewWithContext creates a *logger.Logger. Default values are Debug LogLevel, kayvee Formatter, and std.err output.
+func NewWithContext(source string, context M) *Logger {
+	logObj := Logger{
+		globals: context,
+	}
 	var logLvl LogLevel
 	strLogLvl := os.Getenv("KAYVEE_LOG_LEVEL")
 	if strLogLvl == "" {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -33,6 +33,13 @@ const (
 	Critical
 )
 
+var reservedKeyNames = map[string]bool{
+	"title":  true,
+	"source": true,
+	"value":  true,
+	"type":   true,
+}
+
 var logLevelNames = map[LogLevel]string{
 	Debug:    "debug",
 	Info:     "info",
@@ -219,6 +226,10 @@ func New(source string) *Logger {
 func NewWithContext(source string, contextValues map[string]interface{}) *Logger {
 	context := M{"source": source}
 	for k, v := range contextValues {
+		if reservedKeyNames[strings.ToLower(k)] {
+			log.Printf("WARN: kayvee logger reserves '%s' from being set as context", k)
+			continue
+		}
 		context[k] = v
 	}
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -79,7 +79,11 @@ type Logger struct {
 }
 
 // SetConfig allows configuration changes in one go
-func (l *Logger) SetConfig(logLvl LogLevel, formatter Formatter, output io.Writer) {
+func (l *Logger) SetConfig(source string, logLvl LogLevel, formatter Formatter, output io.Writer) {
+	if l.globals == nil {
+		l.globals = make(map[string]interface{})
+	}
+	l.globals["source"] = source
 	l.logLvl = logLvl
 	l.formatter = formatter
 	l.logWriter = log.New(output, "", 0) // No prefixes
@@ -224,7 +228,7 @@ func New(source string) *Logger {
 
 // NewWithContext creates a *logger.Logger. Default values are Debug LogLevel, kayvee Formatter, and std.err output.
 func NewWithContext(source string, contextValues map[string]interface{}) *Logger {
-	context := M{"source": source}
+	context := M{}
 	for k, v := range contextValues {
 		if reservedKeyNames[strings.ToLower(k)] {
 			log.Printf("WARN: kayvee logger reserves '%s' from being set as context", k)
@@ -249,6 +253,6 @@ func NewWithContext(source string, contextValues map[string]interface{}) *Logger
 			}
 		}
 	}
-	logObj.SetConfig(logLvl, kv.Format, os.Stderr)
+	logObj.SetConfig(source, logLvl, kv.Format, os.Stderr)
 	return &logObj
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -72,12 +72,7 @@ type Logger struct {
 }
 
 // SetConfig allows configuration changes in one go
-func (l *Logger) SetConfig(source string, logLvl LogLevel, formatter Formatter, output io.Writer) {
-	if l.globals == nil {
-		l.globals = make(map[string]interface{})
-	}
-
-	l.globals["source"] = source
+func (l *Logger) SetConfig(logLvl LogLevel, formatter Formatter, output io.Writer) {
 	l.logLvl = logLvl
 	l.formatter = formatter
 	l.logWriter = log.New(output, "", 0) // No prefixes
@@ -221,10 +216,16 @@ func New(source string) *Logger {
 }
 
 // NewWithContext creates a *logger.Logger. Default values are Debug LogLevel, kayvee Formatter, and std.err output.
-func NewWithContext(source string, context M) *Logger {
+func NewWithContext(source string, contextValues map[string]interface{}) *Logger {
+	context := M{"source": source}
+	for k, v := range contextValues {
+		context[k] = v
+	}
+
 	logObj := Logger{
 		globals: context,
 	}
+
 	var logLvl LogLevel
 	strLogLvl := os.Getenv("KAYVEE_LOG_LEVEL")
 	if strLogLvl == "" {
@@ -237,6 +238,6 @@ func NewWithContext(source string, context M) *Logger {
 			}
 		}
 	}
-	logObj.SetConfig(source, logLvl, kv.Format, os.Stderr)
+	logObj.SetConfig(logLvl, kv.Format, os.Stderr)
 	return &logObj
 }


### PR DESCRIPTION
This is a proposal to add an additional constructor that takes a set of key:value pairs that will be added to all logs.
An example use case that this is intended for is including the job ID in all logs from a worker's execution.

Like so:
```go
lg := logger.NewWithContext("file-processor", logger.M{"job_id": os.Getenv("JOB_ID")})
```