### PR TITLE
add loghandler for logging HTTP requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ SHELL := /bin/bash
 PKGS = $(shell go list ./...)
 $(eval $(call golang-version-check,1.6))
 
+export _DEPLOY_ENV=testing
+
 test: tests.json $(PKGS)
 
 $(PKGS): golang-test-all-strict-deps

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ with a "json" format.
 
 ## [Logger API Documentation](./logger)
 
+* (gopkg.in/Clever/kayvee-go.v3/logger)[https://godoc.org/gopkg.in/Clever/kayvee-go.v3/logger]
+* (gopkg.in/Clever/kayvee-go.v3/middleware)[https://godoc.org/gopkg.in/Clever/kayvee-go.v3/middleware]
+
 ## Example
 
 ```go

--- a/kayvee.go
+++ b/kayvee.go
@@ -3,6 +3,7 @@ package kayvee
 import (
 	"encoding/json"
 	"log"
+	"os"
 )
 
 // Log Levels:
@@ -27,6 +28,9 @@ const (
 
 // Format converts a map to a string of space-delimited key=val pairs
 func Format(data map[string]interface{}) string {
+	if os.Getenv("_DEPLOY_ENV") != "" {
+		data["deploy_env"] = os.Getenv("_DEPLOY_ENV")
+	}
 	formattedString, _ := json.Marshal(data)
 	return string(formattedString)
 }

--- a/kayvee.go
+++ b/kayvee.go
@@ -6,6 +6,14 @@ import (
 	"os"
 )
 
+var deployEnv string
+
+func init() {
+	if os.Getenv("_DEPLOY_ENV") != "" {
+		deployEnv = os.Getenv("_DEPLOY_ENV")
+	}
+}
+
 // Log Levels:
 
 // LogLevel denotes the level of a logging
@@ -28,8 +36,8 @@ const (
 
 // Format converts a map to a string of space-delimited key=val pairs
 func Format(data map[string]interface{}) string {
-	if os.Getenv("_DEPLOY_ENV") != "" {
-		data["deploy_env"] = os.Getenv("_DEPLOY_ENV")
+	if deployEnv != "" {
+		data["deploy_env"] = deployEnv
 	}
 	formattedString, _ := json.Marshal(data)
 	return string(formattedString)

--- a/kayvee_test.go
+++ b/kayvee_test.go
@@ -35,6 +35,8 @@ func compareJSONStrings(t *testing.T, expected string, actual string) {
 		t.Fatalf("failed to json unmarshal `expected`: %s", expected)
 	}
 
+	expectedJSON["deploy_env"] = "testing"
+
 	assert.Equal(t, expectedJSON, actualJSON)
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -236,6 +236,9 @@ func NewWithContext(source string, contextValues map[string]interface{}) *Logger
 		}
 		context[k] = v
 	}
+	if os.Getenv("_DEPLOY_ENV") != "" {
+		context["deploy_env"] = os.Getenv("_DEPLOY_ENV")
+	}
 
 	logObj := Logger{
 		globals: context,

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -27,6 +27,8 @@ func compareJSONStrings(t *testing.T, expected string, actual string) {
 		panic(fmt.Sprint("failed to json unmarshal `expected`:", expected))
 	}
 
+	expectedJSON["deploy_env"] = "testing"
+
 	assert.Equal(t, expectedJSON, actualJSON)
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,120 @@
+package kayvee
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+var defaultHandler = func(req *http.Request) map[string]interface{} {
+	return map[string]interface{}{
+		"method": req.Method,
+		"path":   req.URL.Path,
+		"params": req.URL.RawQuery,
+		"ip":     getIP(req),
+	}
+}
+
+// A LogHandler is an http.Handler that logs customizable data about every request.
+type LogHandler struct {
+	source   string
+	handlers []func(req *http.Request) map[string]interface{}
+	h        http.Handler
+}
+
+func (l *LogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	start := time.Now()
+
+	lrw := &loggedResponseWriter{
+		status:         -1,
+		ResponseWriter: w,
+		length:         0,
+	}
+	l.h.ServeHTTP(lrw, req)
+	duration := time.Since(start)
+
+	data := l.applyHandlers(req, map[string]interface{}{
+		"response-time": duration,
+		"response-size": lrw.length,
+		"status-code":   lrw.status,
+		"via":           "kayvee-middleware",
+	})
+
+	log.Println(FormatLog(l.source, logLevelFromStatus(lrw.status), "request-finished", data))
+}
+
+func (l *LogHandler) applyHandlers(req *http.Request, finalizer map[string]interface{}) map[string]interface{} {
+	result := map[string]interface{}{}
+	writeData := func(data map[string]interface{}) {
+		for key, val := range data {
+			result[key] = val
+		}
+	}
+
+	for _, handler := range l.handlers {
+		writeData(handler(req))
+	}
+	// Write reserved fields last to make sure nothing overwrites them
+	writeData(defaultHandler(req))
+	writeData(finalizer)
+
+	return result
+}
+
+// NewLogHandler takes in an http Handler to wrap with logging, the source of that logging, and any
+// amount of optional handlers to customize the data that's logged.
+func NewLogHandler(h http.Handler, source string, handlers ...func(*http.Request) map[string]interface{}) *LogHandler {
+	return &LogHandler{
+		source:   source,
+		handlers: handlers,
+		h:        h,
+	}
+}
+
+// HeaderHandler takes in any amount of headers and returns a handler that adds those headers.
+func HeaderHandler(headers ...string) func(*http.Request) map[string]interface{} {
+	return func(req *http.Request) map[string]interface{} {
+		result := map[string]interface{}{}
+		for _, header := range headers {
+			if val := req.Header.Get(header); val != "" {
+				result[header] = val
+			}
+		}
+		return result
+	}
+}
+
+type loggedResponseWriter struct {
+	status int
+	http.ResponseWriter
+	length int
+}
+
+func (w *loggedResponseWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *loggedResponseWriter) Write(b []byte) (int, error) {
+	if w.status == -1 {
+		w.status = 200
+	}
+	n, err := w.ResponseWriter.Write(b)
+	w.length += n
+	return n, err
+}
+
+func getIP(req *http.Request) string {
+	forwarded := req.Header.Get("X-Forwarded-For")
+	if forwarded != "" {
+		return forwarded
+	}
+	return req.RemoteAddr
+}
+
+func logLevelFromStatus(status int) LogLevel {
+	if status >= 499 {
+		return Error
+	}
+	return Info
+}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -16,14 +16,13 @@ var defaultHandler = func(req *http.Request) map[string]interface{} {
 	}
 }
 
-// A LogHandler is an http.Handler that logs customizable data about every request.
-type LogHandler struct {
+type logHandler struct {
 	handlers []func(req *http.Request) map[string]interface{}
 	h        http.Handler
 	logger   *logger.Logger
 }
 
-func (l *LogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (l *logHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 
 	lrw := &loggedResponseWriter{
@@ -49,7 +48,7 @@ func (l *LogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (l *LogHandler) applyHandlers(req *http.Request, finalizer map[string]interface{}) map[string]interface{} {
+func (l *logHandler) applyHandlers(req *http.Request, finalizer map[string]interface{}) map[string]interface{} {
 	result := map[string]interface{}{}
 	writeData := func(data map[string]interface{}) {
 		for key, val := range data {
@@ -67,10 +66,10 @@ func (l *LogHandler) applyHandlers(req *http.Request, finalizer map[string]inter
 	return result
 }
 
-// NewLogHandler takes in an http Handler to wrap with logging, the logger to use, and any amount of
+// New takes in an http Handler to wrap with logging, the logger to use, and any amount of
 // optional handlers to customize the data that's logged.
-func NewLogHandler(h http.Handler, logger *logger.Logger, handlers ...func(*http.Request) map[string]interface{}) *LogHandler {
-	return &LogHandler{
+func New(h http.Handler, logger *logger.Logger, handlers ...func(*http.Request) map[string]interface{}) http.Handler {
+	return &logHandler{
 		logger:   logger,
 		handlers: handlers,
 		h:        h,

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,3 +1,12 @@
+/*
+Package middleware provides a customizable Kayvee logging middleware for HTTP servers.
+
+	logHandler := New(myHandler, myLogger, func(req *http.Request) map[string]interface{} {
+		// Add Gorilla mux vars to the log, just because
+		return mux.Vays(req)
+	})
+
+*/
 package middleware
 
 import (

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,0 +1,93 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kv "gopkg.in/Clever/kayvee-go.v3"
+	"gopkg.in/Clever/kayvee-go.v3/logger"
+)
+
+type bufferWriter struct {
+	bytes.Buffer
+	status int
+}
+
+func (b *bufferWriter) WriteHeader(status int) {
+	b.status = status
+}
+
+func (b *bufferWriter) Header() http.Header {
+	return nil
+}
+
+func TestMiddleware(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		handler        func(http.ResponseWriter, *http.Request)
+		expectedSize   int
+		expectedStatus int
+		expectedLog    map[string]interface{}
+	}{
+		{
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Write(make([]byte, 10, 10))
+				w.Write(make([]byte, 5, 5))
+			},
+			expectedSize:   10,
+			expectedStatus: 200,
+			// Only the logs that vary based on the handler, the rest are tested in the test runner
+			expectedLog: map[string]interface{}{
+				"level": "info",
+				// Floats because json decoding treats all numbers as floats
+				"response-size": 15.0,
+				"status-code":   200.0,
+			},
+		},
+	}
+	for _, test := range tests {
+		lggr := logger.New("my-source")
+
+		out := &bytes.Buffer{}
+		lggr.SetConfig("my-source", logger.Info, kv.Format, out)
+
+		handler := New(http.HandlerFunc(test.handler), lggr)
+		rw := &bufferWriter{}
+		handler.ServeHTTP(rw, &http.Request{
+			Method: "GET",
+			URL: &url.URL{
+				Host:     "trollhost.com",
+				Path:     "path",
+				RawQuery: "key=val&key2=val2",
+			},
+			Header: http.Header{"X-Forwarded-For": {"192.168.0.1"}},
+		})
+
+		var result map[string]interface{}
+		assert.Nil(json.NewDecoder(out).Decode(&result))
+
+		log.Printf("%#v", result)
+
+		// response-time changes each run, so just check that it's more than zero
+		if result["response-time"].(float64) < 1 {
+			t.Fatalf("invalid response-time %d", result["response-time"])
+		}
+		delete(result, "response-time")
+
+		test.expectedLog["ip"] = "192.168.0.1"
+		test.expectedLog["path"] = "path"
+		test.expectedLog["method"] = "GET"
+		test.expectedLog["title"] = "request-finished"
+		test.expectedLog["via"] = "kayvee-middleware"
+		test.expectedLog["params"] = "key=val&key2=val2"
+		test.expectedLog["source"] = "my-source"
+
+		assert.Equal(test.expectedLog, result)
+	}
+}

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -40,8 +40,6 @@ func TestMiddleware(t *testing.T) {
 				w.Write(make([]byte, 10, 10))
 				w.Write(make([]byte, 5, 5))
 			},
-			expectedSize:   10,
-			expectedStatus: 200,
 			// Only the logs that vary based on the handler, the rest are tested in the test runner
 			expectedLog: map[string]interface{}{
 				"level": "info",
@@ -87,6 +85,7 @@ func TestMiddleware(t *testing.T) {
 		test.expectedLog["via"] = "kayvee-middleware"
 		test.expectedLog["params"] = "key=val&key2=val2"
 		test.expectedLog["source"] = "my-source"
+		test.expectedLog["deploy_env"] = "testing"
 
 		assert.Equal(test.expectedLog, result)
 	}


### PR DESCRIPTION
This is the Go equivalent of kayvee-js's express middleware for logging (https://github.com/Clever/kayvee-js/pull/13).