### PR TITLE
support empty handlers

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -35,7 +35,7 @@ func (l *logHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 
 	lrw := &loggedResponseWriter{
-		status:         -1,
+		status:         200,
 		ResponseWriter: w,
 		length:         0,
 	}
@@ -110,9 +110,6 @@ func (w *loggedResponseWriter) WriteHeader(code int) {
 }
 
 func (w *loggedResponseWriter) Write(b []byte) (int, error) {
-	if w.status == -1 {
-		w.status = 200
-	}
 	n, err := w.ResponseWriter.Write(b)
 	w.length += n
 	return n, err

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -48,6 +48,25 @@ func TestMiddleware(t *testing.T) {
 				"status-code":   200.0,
 			},
 		},
+		{
+			// Empty handler is totally valid and should send back 200 with a response size of 0
+			handler: func(w http.ResponseWriter, r *http.Request) {},
+			expectedLog: map[string]interface{}{
+				"level":         "info",
+				"response-size": 0.0,
+				"status-code":   200.0,
+			},
+		},
+		{
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(500)
+			},
+			expectedLog: map[string]interface{}{
+				"level":         "error",
+				"response-size": 0.0,
+				"status-code":   500.0,
+			},
+		},
 	}
 	for _, test := range tests {
 		lggr := logger.New("my-source")


### PR DESCRIPTION
We routinely use an empty handler for health checks and it was showing
status code of -1, which is incorrect