### PR TITLE
Context methods

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 env:
 - REPORT_CARD_GITHUB_STATUS_TOKEN=$$report_card_github_status_token
 - REPORT_CARD_GITHUB_REPO_TOKEN=$$report_card_github_repo_token
-image: clever/drone-go:1.6
+image: clever/drone-go:1.7
 notify:
   email:
     recipients:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,6 @@ notify:
 script:
 - sudo pip install -q git+https://$REPORT_CARD_GITHUB_REPO_TOKEN@github.com/Clever/report-card.git; GITHUB_API_TOKEN=$REPORT_CARD_GITHUB_STATUS_TOKEN report-card --publish || true
 - mkdir -p $GOPATH/src/gopkg.in/Clever
-- mv `pwd` $GOPATH/src/gopkg.in/Clever/kayvee-go.v3
-- cd $GOPATH/src/gopkg.in/Clever/kayvee-go.v3
+- mv `pwd` $GOPATH/src/gopkg.in/Clever/kayvee-go.v4
+- cd $GOPATH/src/gopkg.in/Clever/kayvee-go.v4
 - make test

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include golang.mk
 .PHONY: test $(PKGS)
 SHELL := /bin/bash
 PKGS = $(shell go list ./...)
-$(eval $(call golang-version-check,1.6))
+$(eval $(call golang-version-check,1.7))
 
 export _DEPLOY_ENV=testing
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # kayvee
 --
-    import "gopkg.in/Clever/kayvee-go.v3"
+    import "gopkg.in/Clever/kayvee-go.v4"
 
 Package kayvee provides methods to output human and machine parseable strings,
 with a "json" format.
 
 ## [Logger API Documentation](./logger)
 
-* [gopkg.in/Clever/kayvee-go.v3/logger](https://godoc.org/gopkg.in/Clever/kayvee-go.v3/logger)
-* [gopkg.in/Clever/kayvee-go.v3/middleware](https://godoc.org/gopkg.in/Clever/kayvee-go.v3/middleware)
+* [gopkg.in/Clever/kayvee-go.v4/logger](https://godoc.org/gopkg.in/Clever/kayvee-go.v4/logger)
+* [gopkg.in/Clever/kayvee-go.v4/middleware](https://godoc.org/gopkg.in/Clever/kayvee-go.v4/middleware)
 
 ## Example
 
@@ -19,7 +19,7 @@ with a "json" format.
         "fmt"
         "time"
 
-        "gopkg.in/Clever/kayvee-go.v3/logger"
+        "gopkg.in/Clever/kayvee-go.v4/logger"
     )
 
     func main() {
@@ -51,7 +51,7 @@ Run `make test` to execute the tests
   - Added methods to read and write the `Logger` object from a a `context.Context` object.
   - Middleware now injects the logger into the request context.
   - Updated to require Go 1.7.
-- v3.0 - Removed sentry-go dependency
+- v4.0 - Removed sentry-go dependency
 - v2.4 - Add kayvee-go/validator for asserting that raw log lines are in a valid kayvee format.
 - v2.3 - Expose logger.M.
 - v2.2 - Remove godeps.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Run `make test` to execute the tests
 
 ## Change log
 
+- v4.0
+  - Added methods to read and write the `Logger` object from a a `context.Context` object.
+  - Middleware now injects the logger into the request context.
+  - Updated to require Go 1.7.
 - v3.0 - Removed sentry-go dependency
 - v2.4 - Add kayvee-go/validator for asserting that raw log lines are in a valid kayvee format.
 - v2.3 - Expose logger.M.
@@ -57,4 +61,3 @@ Run `make test` to execute the tests
 ## Backward Compatibility
 
 The kayvee 1.x interface still exist but is considered deprecated. You can find documentation on using it in the [compatibility guide](./compatibility.md)
-

--- a/logger/README.md
+++ b/logger/README.md
@@ -1,6 +1,6 @@
 # logger
 --
-    import "gopkg.in/Clever/kayvee-go.v3/logger"
+    import "gopkg.in/Clever/kayvee-go.v4/logger"
 
 
 ## Usage

--- a/logger/context.go
+++ b/logger/context.go
@@ -1,0 +1,25 @@
+package logger
+
+import "context"
+
+type loggerKeyType struct{}
+
+var loggerKey = loggerKeyType{}
+
+// NewContext creates a new context object containing a logger value.
+func NewContext(ctx context.Context, logger *Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// FromContext returns the logger value contained in a context.
+// For convenience, if the context does not contain a logger, a new logger is
+// created and returned. This allows users of this method to use the logger
+// immediately, e.g.
+//   logger.FromContext(ctx).Info("...")
+func FromContext(ctx context.Context) *Logger {
+	logger := ctx.Value(loggerKey)
+	if lggr, ok := logger.(*Logger); ok {
+		return lggr
+	}
+	return New("")
+}

--- a/logger/context_test.go
+++ b/logger/context_test.go
@@ -1,0 +1,19 @@
+package logger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromContext(t *testing.T) {
+	loggerFromEmptyContext := FromContext(context.Background())
+	assert.NotNil(t, loggerFromEmptyContext, "FromContext should return a non-nil logger, even if the context does not contain a logger")
+
+	logger := New("logger-from-context")
+	ctx := context.Background()
+	ctx = NewContext(ctx, logger)
+	loggerFromContext := FromContext(ctx)
+	assert.Equal(t, logger, loggerFromContext, "Logger retrieved from context should be the same one we placed in the context")
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	kv "gopkg.in/Clever/kayvee-go.v3"
+	kv "gopkg.in/Clever/kayvee-go.v4"
 )
 
 /////////////////////

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	kv "gopkg.in/Clever/kayvee-go.v3"
+	kv "gopkg.in/Clever/kayvee-go.v4"
 )
 
 type keyVal map[string]interface{}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -34,6 +34,9 @@ type logHandler struct {
 func (l *logHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 
+	// inject the logger into req.Context
+	req = req.WithContext(logger.NewContext(req.Context(), l.logger))
+
 	lrw := &loggedResponseWriter{
 		status:         200,
 		ResponseWriter: w,

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"time"
 
-	"gopkg.in/Clever/kayvee-go.v3/logger"
+	"gopkg.in/Clever/kayvee-go.v4/logger"
 )
 
 var defaultHandler = func(req *http.Request) map[string]interface{} {

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	kv "gopkg.in/Clever/kayvee-go.v3"
-	"gopkg.in/Clever/kayvee-go.v3/logger"
+	kv "gopkg.in/Clever/kayvee-go.v4"
+	"gopkg.in/Clever/kayvee-go.v4/logger"
 )
 
 type bufferWriter struct {

--- a/validator/README.md
+++ b/validator/README.md
@@ -1,6 +1,6 @@
 # validator
 --
-    import "gopkg.in/Clever/kayvee-go.v3/validator"
+    import "gopkg.in/Clever/kayvee-go.v4/validator"
 
 
 ## Usage

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/Clever/kayvee-go.v3/logger"
+	"gopkg.in/Clever/kayvee-go.v4/logger"
 )
 
 // ValueType represents the valuve type of a Kayvee field, where applicable.


### PR DESCRIPTION
This adds the ability to read/write a `Logger` object from/to a Go 1.7 `context.Context` object.

It also changes the `middleware` package to to inject the middleware logger into `req.Context()`.

This lets you access the kayvee middleware logger in request handlers for additional logging.

One thing I'm not sure the answer to: this requires go 1.7, so what should the version bump be?