### PR TITLE
AddContext method

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -89,6 +89,11 @@ func (l *Logger) SetConfig(source string, logLvl LogLevel, formatter Formatter, 
 	l.logWriter = log.New(output, "", 0) // No prefixes
 }
 
+// AddContext adds a new key-val to be logged with all log messages.
+func (l *Logger) AddContext(key, val string) {
+	l.globals[key] = val
+}
+
 // SetLogLevel sets the default log level threshold
 func (l *Logger) SetLogLevel(logLvl LogLevel) {
 	l.logLvl = logLvl

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -209,3 +209,17 @@ func TestMultipleLoggers(t *testing.T) {
 	logger2.Info("testloginfo")
 	assert.NotEqual(t, logOutput1, string(buf1.Bytes()))
 }
+
+func TestAddContext(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New("logger-tester")
+	logger.SetOutput(buf)
+	logger.Info("1")
+	assertLogFormatAndCompareContent(t, string(buf.Bytes()),
+		kv.FormatLog("logger-tester", kv.Info, "1", M{}))
+	buf.Reset()
+	logger.AddContext("a", "b")
+	logger.Info("2")
+	assertLogFormatAndCompareContent(t, string(buf.Bytes()),
+		kv.FormatLog("logger-tester", kv.Info, "2", M{"a": "b"}))
+}


### PR DESCRIPTION
This adds a new method `AddContext` that adds to the `globals` map of data that will be logged with a logger. This is useful in HTTP middleware, e.g. in tracing middleware, you might want to add the span ID:

```go
logger.FromContext(r.Context()).AddContext("ot-tracer-spanid", spanid)
```

or when setting up route handlers, you might want to inject the operation ID:

```go
 	r.Methods("POST").Path("/jobs").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		logger.FromContext(r.Context()).AddContext("op", "createJob")
 		h.CreateJobHandler(r.Context(), w, r)
 	})
```

or when you respond 400/500, you might want to inject the error:

```go
	if err := input.Validate(); err != nil {
		logger.FromContext(ctx).AddContext("error", err.Error())
		http.Error(w, ..., http.StatusBadRequest)
		return
	}
```

The end result are much more useful kv middleware logs in the case of failure, e.g. instead of 

```
[matchmaker-service]	 {"ip":"127.0.0.1:38122","level":"info","method":"GET","params":"","path":"/jobs/adsf","response-size":51,"response-time":191630,"source":"Matchmaker service","status-code":400,"title":"request-finished","via":"kayvee-middleware"}
```

you get the much more debuggable

```
[matchmaker-service]	 {"error":"id in path should match '^[0-9a-f]{24}$'","ip":"127.0.0.1:38116","level":"info","method":"GET","op":"getJob","ot-tracer-spanid":"7bc36786d68f575f","params":"","path":"/jobs/adsf","response-size":51,"response-time":171429,"source":"Matchmaker service","status-code":400,"title":"request-finished","via":"kayvee-middleware"}

```

