### PR TITLE
Better bumping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include golang.mk
 .DEFAULT_GOAL := test # override default goal set in library makefile
 
-.PHONY: test bump-major bump-minor bump-patch $(PKGS)
+.PHONY: test bump-major bump-minor bump-patch tag-version $(PKGS)
 SHELL := /bin/bash
 PKGS = $(shell go list ./...)
 $(eval $(call golang-version-check,1.7))
@@ -18,7 +18,6 @@ define set-version
 @echo "var Version = \"$(VERS)\"" >> version.go
 @git add VERSION version.go
 @git commit -m "Bump to v$(VERS)"
-@git tag v$(VERS)
 endef
 
 bump-major:
@@ -34,6 +33,10 @@ bump-minor:
 bump-patch:
 	$(eval VERS := $(shell cat VERSION | awk 'BEGIN{FS="."} {print $$1 "." $$2 "." $$3+1}'))
 	$(call set-version)
+
+tag-version:
+	$(eval VERS := $(shell cat VERSION))
+	@git tag v$(VERS)
 
 test: tests.json $(PKGS)
 

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ define set-version
 endef
 
 bump-major:
-	$(eval VERS := $(shell cat VERSION | awk 'BEGIN{FS="."} {print $$1+1 "." $$2 "." $$3}'))
+	$(eval VERS := $(shell cat VERSION | awk 'BEGIN{FS="."} {print $$1+1 ".0.0"}'))
 	$(eval MAJOR_VERS := $(firstword $(subst ., ,$(VERS))))
 	@find . -exec sed -i 's/gopkg\.in\/Clever\/kayvee-go\.v[[:digit:]]\+/gopkg\.in\/Clever\/kayvee-go\.v$(MAJOR_VERS)/' {} \;
 	$(call set-version)
 
 bump-minor:
-	$(eval VERS := $(shell cat VERSION | awk 'BEGIN{FS="."} {print $$1 "." $$2+1 "." $$3}'))
+	$(eval VERS := $(shell cat VERSION | awk 'BEGIN{FS="."} {print $$1 "." $$2+1 ".0"}'))
 	$(call set-version)
 
 bump-patch:

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,11 @@
 **Overview:**
 
+**Pre-merge:**
+- [ ] Before merging to `master`, make sure that a new version hasn't been
+  merged. Then, use `make bump-major`, `make bump-minor`, or `make bump-patch`
+  to bump the version number in VERSION and version.go (and all files that
+  reference gopkg.in if a major bump).
+
 **Post-merge:**
-- [ ] After merging to `master`, Use `make bump-major`, `make bump-minor`, or `make bump-patch` to bump
-  the version number in git, VERSION, and version.go. Then, run `git push
-  --tags` to push the new tag.
+- [ ] After merging to `master`, Use `make tag-version` to set the version
+  number in a git tag. Then, run `git push --tags` to push the new tag.


### PR DESCRIPTION
**Overview:**
This fixes a bug in version bumping, and also separates the bump commit from tagging since our github config prevents pushing commits to master that haven't passed CI, so you can't push a commit directly to master.