### PR TITLE
Add mock logger that counts routes matched

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,21 @@ with a "json" format.
         "gopkg.in/Clever/kayvee-go.v5/logger"
     )
 
-    func main() {
-        myLogger := logger.New("myApp")
+    var log = logger.New("myApp")
 
+    func main() {
         // Simple debugging
-        myLogger.Debug("Service has started")
+        log.Debug("Service has started")
 
         // Make a query and log its length
         query_start := time.Now()
-        myLogger.GaugeFloat("QueryTime", time.Since(query_start).Seconds())
+        log.GaugeFloat("QueryTime", time.Since(query_start).Seconds())
 
         // Output structured data
-        myLogger.InfoD("DataResults", logger.M{"key": "value"})
+        log.InfoD("DataResults", logger.M{"key": "value"})
 
         // You can use the M alias for your key value pairs
-        myLogger.InfoD("DataResults", logger.M{"shorter": "line"})
+        log.InfoD("DataResults", logger.M{"shorter": "line"})
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,40 +10,104 @@ with a "json" format.
 * [gopkg.in/Clever/kayvee-go.v5/logger](https://godoc.org/gopkg.in/Clever/kayvee-go.v5/logger)
 * [gopkg.in/Clever/kayvee-go.v5/middleware](https://godoc.org/gopkg.in/Clever/kayvee-go.v5/middleware)
 
-## Example
+## Examples
 
 ```go
-    package main
+// main.go
+package main
 
-    import(
-        "fmt"
-        "time"
+import (
+    "time"
 
-        "gopkg.in/Clever/kayvee-go.v5/logger"
-    )
+    "gopkg.in/Clever/kayvee-go.v5/logger"
+)
 
-    var log = logger.New("myApp")
+var log logger.KayveeLogger
 
-    func main() {
-        // Simple debugging
-        log.Debug("Service has started")
+func init() {
+    var err error
+    log, err = logger.New("myApp").WithRoutingConfig("./kvconfig.yml")
 
-        // Make a query and log its length
-        query_start := time.Now()
-        log.GaugeFloat("QueryTime", time.Since(query_start).Seconds())
-
-        // Output structured data
-        log.InfoD("DataResults", logger.M{"key": "value"})
-
-        // You can use the M alias for your key value pairs
-        log.InfoD("DataResults", logger.M{"shorter": "line"})
+    if err != nil {
+        panic(err)
     }
+}
+
+func main() {
+    // Simple debugging
+    log.Debug("Service has started")
+
+    // Make a query and log its length
+    query_start := time.Now()
+    log.GaugeFloat("QueryTime", time.Since(query_start).Seconds())
+
+    // Output structured data
+    log.InfoD("DataResults", logger.M{"key": "value"})
+
+    // You can use the M alias for your key value pairs
+    log.InfoD("DataResults", logger.M{"shorter": "line"})
+}
 ```
 
+## Log Routing
+
+Log routing is a mechanism for defining where log lines should go once they've entered Clever's logging pipeline.   Routes are defined in a yaml file called kvconfig.yml.  Here's an example of a log routing rule that sends a slack message:
+
+```yaml
+# kvconfig.yml
+routes:
+  key-val: # Rule name
+    matchers:
+      title: [ "DataResults", "QueryResults" ]
+      key: [ "value" ]
+    output: # Routes log line to #data-dinesty slack channel
+      type: "notifications"
+      channel: "#data-dinesty"
+      icon: ":bird:"
+      message: "The data is in: %{key}"
+      user: "The Data Duck"
+```
+
+For more information see https://clever.atlassian.net/wiki/display/ENG/Log+Routing
 
 ## Testing
 
 Run `make test` to execute the tests
+
+### Testing Log Routing
+
+A mock logger is provided to make it easier to test log routing rules.  Here's an exampe:
+
+```go
+// Units for main.go which is defined in the examples section of this README
+package main
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "gopkg.in/Clever/kayvee-go.v5/logger"
+)
+
+func TestDataResultsRouting(t *testing.T) {
+    assert := assert.New(t)
+
+    mocklog := logger.NewMockCountLogger("myApp")
+
+    var err error
+    // Overrides package level logger
+    log, err = mocklog.WithRoutingConfig("./kvconfig.yml")
+    assert.NoError(err)
+
+    main() // Call function to generate log lines
+
+    counts := mocklog.RuleCounts()
+
+    assert.Contains(counts, "key-val")
+    assert.Equal(counts["key-val"], 1)
+}
+```
+
 
 ## Change log
 

--- a/benchmarks/routing_test.go
+++ b/benchmarks/routing_test.go
@@ -18,10 +18,10 @@ var basicCorpus []logline
 var pathologicalCorpus []logline
 var realisticCorpus []logline
 
-var noRouting *logger.Logger
-var basicRouting *logger.Logger
-var pathoRouting *logger.Logger
-var realRouting *logger.Logger
+var noRouting logger.KayveeLogger
+var basicRouting logger.KayveeLogger
+var pathoRouting logger.KayveeLogger
+var realRouting logger.KayveeLogger
 
 func loadJSON(path string, o interface{}) error {
 	file, err := ioutil.ReadFile(path)

--- a/logger/kayvee_logger.go
+++ b/logger/kayvee_logger.go
@@ -1,0 +1,91 @@
+package logger
+
+import (
+	"io"
+)
+
+/////////////////////////////
+//
+//	KayveeLogger interface
+//
+/////////////////////////////
+
+// KayveeLogger is the main logging interface, providing customization of log messages.
+type KayveeLogger interface {
+
+	//
+	// Configuration
+	//
+
+	// AddContext adds a new key-val to be logged with all log messages.
+	AddContext(key, val string)
+
+	// SetConfig allows configuration changes in one go
+	SetConfig(source string, logLvl LogLevel, formatter Formatter, output io.Writer)
+
+	// SetFormatter sets the formatter function to use
+	SetFormatter(formatter Formatter)
+
+	// SetLogLevel sets the default log level threshold
+	SetLogLevel(logLvl LogLevel)
+
+	// SetOutput changes the output destination of the logger
+	SetOutput(output io.Writer)
+
+	// WithRoutingConfig installs a new log router onto the KayveeLogger with the
+	// configuration specified in `filename`. For convenience, the KayveeLogger is expected
+	// to return itself as the first return value.
+	WithRoutingConfig(filename string) (KayveeLogger, error)
+
+	//
+	// Logging
+	//
+
+	// Counter takes a string and logs with LogLevel = Info
+	Counter(title string)
+
+	// CounterD takes a string, value, and data map. It logs with LogLevel = Info
+	CounterD(title string, value int, data map[string]interface{})
+
+	// Critical takes a string and logs with LogLevel = Critical
+	Critical(title string)
+
+	// CriticalD takes a string and data map. It logs with LogLevel = Critical
+	CriticalD(title string, data map[string]interface{})
+
+	// Debug takes a string and logs with LogLevel = Debug
+	Debug(title string)
+
+	// DebugD takes a string and data map. It logs with LogLevel = Debug
+	DebugD(title string, data map[string]interface{})
+
+	// Error takes a string and logs with LogLevel = Error
+	Error(title string)
+
+	// ErrorD takes a string and data map. It logs with LogLevel = Error
+	ErrorD(title string, data map[string]interface{})
+
+	// GaugeFloat takes a string and float value. It logs with LogLevel = Info
+	GaugeFloat(title string, value float64)
+
+	// GaugeFloatD takes a string, a float value, and data map. It logs with LogLevel = Info
+	GaugeFloatD(title string, value float64, data map[string]interface{})
+
+	// GaugeInt takes a string and integer value. It logs with LogLevel = Info
+	GaugeInt(title string, value int)
+
+	// GaugeIntD takes a string, an integer value, and data map. It logs with LogLevel = Info
+	GaugeIntD(title string, value int, data map[string]interface{})
+
+	// Info takes a string and logs with LogLevel = Info
+	Info(title string)
+
+	// InfoD takes a string and data map. It logs with LogLevel = Info
+	InfoD(title string, data map[string]interface{})
+
+	// Warn takes a string and logs with LogLevel = Warning
+	Warn(title string)
+
+	// WarnD takes a string and data map. It logs with LogLevel = Warning
+	WarnD(title string, data map[string]interface{})
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -73,7 +73,6 @@ type Logger struct {
 	logRouter router.Router
 }
 
-// SetConfig allows configuration changes in one go
 var reservedKeyNames = map[string]bool{
 	"title":   true,
 	"source":  true,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -19,11 +19,11 @@ import (
 // Formatter is a function type that takes a map and returns a formatted string with the contents of the map
 type Formatter func(data map[string]interface{}) string
 
-// LogLevel is an enum is used to denote level of logging
-type LogLevel int
-
 // M is a convenience type for passing data into a log message.
 type M map[string]interface{}
+
+// LogLevel is an enum is used to denote level of logging
+type LogLevel int
 
 // Constants used to define different LogLevels supported
 const (
@@ -33,15 +33,6 @@ const (
 	Error
 	Critical
 )
-
-var reservedKeyNames = map[string]bool{
-	"title":   true,
-	"source":  true,
-	"value":   true,
-	"type":    true,
-	"level":   true,
-	"_kvmeta": true,
-}
 
 var logLevelNames = map[LogLevel]string{
 	Debug:    "debug",
@@ -73,7 +64,8 @@ func (l LogLevel) String() string {
 //
 /////////////////////////////
 
-// Logger provides customization of log messages. We can change globals, default log level, formatting, and output destination.
+// Logger is the default implementation of KayveeLogger.
+// It provides customization of globals, default log level, formatting, and output destination.
 type Logger struct {
 	globals   map[string]interface{}
 	logLvl    LogLevel
@@ -83,6 +75,16 @@ type Logger struct {
 }
 
 // SetConfig allows configuration changes in one go
+var reservedKeyNames = map[string]bool{
+	"title":   true,
+	"source":  true,
+	"value":   true,
+	"type":    true,
+	"level":   true,
+	"_kvmeta": true,
+}
+
+// SetConfig implements the method for the KayveeLogger interface.
 func (l *Logger) SetConfig(source string, logLvl LogLevel, formatter Formatter, output io.Writer) {
 	if l.globals == nil {
 		l.globals = make(map[string]interface{})
@@ -93,99 +95,101 @@ func (l *Logger) SetConfig(source string, logLvl LogLevel, formatter Formatter, 
 	l.logWriter = log.New(output, "", 0) // No prefixes
 }
 
-// AddContext adds or updates a key-val to be logged with all log messages.
+// AddContext implements the method for the KayveeLogger interface.
 func (l *Logger) AddContext(key, val string) {
 	updateContextMapIfNotReserved(l.globals, key, val)
 }
 
-// SetLogLevel sets the default log level threshold
+// SetLogLevel implements the method for the KayveeLogger interface.
 func (l *Logger) SetLogLevel(logLvl LogLevel) {
 	l.logLvl = logLvl
 }
 
-// SetFormatter sets the formatter function to use
+// SetFormatter implements the method for the KayveeLogger interface.
 func (l *Logger) SetFormatter(formatter Formatter) {
 	l.formatter = formatter
 }
 
-// SetOutput changes the output destination of the logger
+// SetOutput implements the method for the KayveeLogger interface.
 func (l *Logger) SetOutput(output io.Writer) {
 	l.logWriter = log.New(output, "", 0) // No prefixes
 }
 
-// Logging functions
-
-// Debug takes a string and logs with LogLevel = Debug
+// Debug implements the method for the KayveeLogger interface.
 func (l *Logger) Debug(title string) {
 	l.DebugD(title, M{})
 }
 
-// Info takes a string and logs with LogLevel = Info
+// Info implements the method for the KayveeLogger interface.
 func (l *Logger) Info(title string) {
 	l.InfoD(title, M{})
 }
 
-// Warn takes a string and logs with LogLevel = Warning
+// Warn implements the method for the KayveeLogger interface.
 func (l *Logger) Warn(title string) {
 	l.WarnD(title, M{})
 }
 
-// Error takes a string and logs with LogLevel = Error
+// Error implements the method for the KayveeLogger interface.
 func (l *Logger) Error(title string) {
 	l.ErrorD(title, M{})
 }
 
-// Critical takes a string and logs with LogLevel = Critical
+// Critical implements the method for the KayveeLogger interface.
 func (l *Logger) Critical(title string) {
 	l.CriticalD(title, M{})
 }
 
-// Counter takes a string and logs with LogLevel = Info, type = counter, and value = 1
+// Counter implements the method for the KayveeLogger interface.
+// Logs with type = gauge, and value = value
 func (l *Logger) Counter(title string) {
 	l.CounterD(title, 1, M{}) // Defaults to a value of 1
 }
 
-// GaugeInt takes a string and integer value. It logs with LogLevel = Info, type = gauge, and value = value
+// GaugeInt implements the method for the KayveeLogger interface.
+// Logs with type = gauge, and value = value
 func (l *Logger) GaugeInt(title string, value int) {
 	l.GaugeIntD(title, value, M{})
 }
 
-// GaugeFloat takes a string and float value. It logs with LogLevel = Info, type = gauge, and value = value
+// GaugeFloat implements the method for the KayveeLogger interface.
+// Logs with type = gauge, and value = value
 func (l *Logger) GaugeFloat(title string, value float64) {
 	l.GaugeFloatD(title, value, M{})
 }
 
-// DebugD takes a string and data map. It logs with LogLevel = Debug
+// DebugD implements the method for the KayveeLogger interface.
 func (l *Logger) DebugD(title string, data map[string]interface{}) {
 	data["title"] = title
 	l.logWithLevel(Debug, data)
 }
 
-// InfoD takes a string and data map. It logs with LogLevel = Info
+// InfoD implements the method for the KayveeLogger interface.
 func (l *Logger) InfoD(title string, data map[string]interface{}) {
 	data["title"] = title
 	l.logWithLevel(Info, data)
 }
 
-// WarnD takes a string and data map. It logs with LogLevel = Warning
+// WarnD implements the method for the KayveeLogger interface.
 func (l *Logger) WarnD(title string, data map[string]interface{}) {
 	data["title"] = title
 	l.logWithLevel(Warning, data)
 }
 
-// ErrorD takes a string and data map. It logs with LogLevel = Error
+// ErrorD implements the method for the KayveeLogger interface.
 func (l *Logger) ErrorD(title string, data map[string]interface{}) {
 	data["title"] = title
 	l.logWithLevel(Error, data)
 }
 
-// CriticalD takes a string and data map. It logs with LogLevel = Critical
+// CriticalD implements the method for the KayveeLogger interface.
 func (l *Logger) CriticalD(title string, data map[string]interface{}) {
 	data["title"] = title
 	l.logWithLevel(Critical, data)
 }
 
-// CounterD takes a string, value, and data map. It logs with LogLevel = Info, type = counter, and value = value
+// CounterD implements the method for the KayveeLogger interface.
+// Logs with type = gauge, and value = value
 func (l *Logger) CounterD(title string, value int, data map[string]interface{}) {
 	data["title"] = title
 	data["value"] = value
@@ -193,12 +197,14 @@ func (l *Logger) CounterD(title string, value int, data map[string]interface{}) 
 	l.logWithLevel(Info, data)
 }
 
-// GaugeIntD takes a string, an integer value, and data map. It logs with LogLevel = Info, type = gauge, and value = value
+// GaugeIntD implements the method for the KayveeLogger interface.
+// Logs with type = gauge, and value = value
 func (l *Logger) GaugeIntD(title string, value int, data map[string]interface{}) {
 	l.gauge(title, value, data)
 }
 
-// GaugeFloatD takes a string, a float value, and data map. It logs with LogLevel = Info, type = gauge, and value = value
+// GaugeFloatD implements the method for the KayveeLogger interface.
+// Logs with type = gauge, and value = value
 func (l *Logger) GaugeFloatD(title string, value float64, data map[string]interface{}) {
 	l.gauge(title, value, data)
 }
@@ -242,10 +248,8 @@ func updateContextMapIfNotReserved(context M, key string, val interface{}) {
 	context[key] = val
 }
 
-// WithRoutingConfig installs a new log router onto the Logger with the
-// configuration specified in `filename`. For convenience, the Logger returns
-// itself as the first return value.
-func (l *Logger) WithRoutingConfig(filename string) (*Logger, error) {
+// WithRoutingConfig implements the method for the KayveeLogger interface.
+func (l *Logger) WithRoutingConfig(filename string) (KayveeLogger, error) {
 	routes, err := router.NewFromConfig(filename)
 	if err != nil {
 		return l, err

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -272,3 +272,7 @@ func (m *MockRouter) Route(msg map[string]interface{}) map[string]interface{} {
 	assertLogFormatAndCompareContent(m.t, expected, kv.Format(msg))
 	return map[string]interface{}{"routekey": 42}
 }
+
+func TestLoggerImplementsKayveeLogger(t *testing.T) {
+	assert.Implements(t, (*KayveeLogger)(nil), &Logger{}, "*Logger should implement KayveeLogger")
+}

--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -11,10 +11,10 @@ type MockRouteCountLogger struct {
 	routeCounts map[string]int
 }
 
-// GetRuleCounts returns a map of rule names to the number of times that rule has been applied
+// RuleCounts returns a map of rule names to the number of times that rule has been applied
 // in routing logs for MockRouteCountLogger. Only includes routing rules that have at least
 // one use.
-func (ml *MockRouteCountLogger) GetRuleCounts() map[string]int {
+func (ml *MockRouteCountLogger) RuleCounts() map[string]int {
 	out := make(map[string]int)
 	for k, v := range ml.routeCounts {
 		out[k] = v

--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -1,0 +1,200 @@
+package logger
+
+import (
+	"io"
+)
+
+// MockRouteCountLogger is a mock implementation of KayveeLogger that counts the router rules
+// applied to each log call without actually formatting or writing the log line.
+type MockRouteCountLogger struct {
+	logger      *Logger
+	routeCounts map[string]int
+}
+
+// GetRuleCounts returns a map of rule names to the number of times that rule has been applied
+// in routing logs for MockRouteCountLogger. Only includes routing rules that have at least
+// one use.
+func (ml *MockRouteCountLogger) GetRuleCounts() map[string]int {
+	out := make(map[string]int)
+	for k, v := range ml.routeCounts {
+		out[k] = v
+	}
+	return out
+}
+
+// NewMockCountLogger returns a new MockRoutCountLogger with the specified `source`.
+func NewMockCountLogger(source string) *MockRouteCountLogger {
+	return NewMockCountLoggerWithContext(source, nil)
+}
+
+// NewMockCountLoggerWithContext returns a new MockRoutCountLogger with the specified `source` and `contextValues`.
+func NewMockCountLoggerWithContext(source string, contextValues map[string]interface{}) *MockRouteCountLogger {
+	routeCounts := make(map[string]int)
+	lg := NewWithContext(source, contextValues)
+	lg.fLogger = &routeCountingFormatLogger{
+		routeCounts: routeCounts,
+	}
+	mocklg := MockRouteCountLogger{
+		logger:      lg,
+		routeCounts: routeCounts,
+	}
+	return &mocklg
+}
+
+/////////////////////////////
+//
+// routeCountingFormatLogger
+//
+/////////////////////////////
+
+// routeCountingFormatLogger implements the formatLogger interface to allow for counting
+// invocations of routing rules.
+type routeCountingFormatLogger struct {
+	routeCounts map[string]int
+}
+
+// formatAndLog tracks routing statistics for this mock router.
+// Initialization works as with the default format logger, but no formatting or logging is actually performed.
+func (fl *routeCountingFormatLogger) formatAndLog(data map[string]interface{}) {
+	routeData, ok := data["_kvmeta"]
+	if !ok {
+		return
+	}
+	routes, ok := routeData.(map[string]interface{})["routes"]
+	if !ok {
+		return
+	}
+	for _, route := range routes.([]map[string]interface{}) {
+		rule := route["rule"].(string)
+		fl.routeCounts[rule] = fl.routeCounts[rule] + 1
+	}
+}
+
+// setFormatter implements the FormatLogger method.
+func (fl *routeCountingFormatLogger) setFormatter(formatter Formatter) {
+	// we don't format anything in this mock logger
+	return
+}
+
+// setOutput implements the FormatLogger method.
+func (fl *routeCountingFormatLogger) setOutput(output io.Writer) {
+	// we don't output anything in this mock logger
+	return
+}
+
+/////////////////////////////////////////////////////////////
+//
+//	KayveeLogger implementation (all passthrough to logger)
+//
+/////////////////////////////////////////////////////////////
+
+// SetConfig implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) SetConfig(source string, logLvl LogLevel, formatter Formatter, output io.Writer) {
+	ml.logger.SetConfig(source, logLvl, formatter, output)
+}
+
+// AddContext implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) AddContext(key, val string) {
+	ml.logger.AddContext(key, val)
+}
+
+// SetLogLevel implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) SetLogLevel(logLvl LogLevel) {
+	ml.logger.SetLogLevel(logLvl)
+}
+
+// SetFormatter implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) SetFormatter(formatter Formatter) {
+	ml.logger.SetFormatter(formatter)
+}
+
+// SetOutput implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) SetOutput(output io.Writer) {
+	ml.logger.SetOutput(output)
+}
+
+// Debug implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) Debug(title string) {
+	ml.logger.Debug(title)
+}
+
+// Info implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) Info(title string) {
+	ml.logger.Info(title)
+}
+
+// Warn implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) Warn(title string) {
+	ml.logger.Warn(title)
+}
+
+// Error implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) Error(title string) {
+	ml.logger.Error(title)
+}
+
+// Critical implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) Critical(title string) {
+	ml.logger.Critical(title)
+}
+
+// Counter implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) Counter(title string) {
+	ml.logger.Counter(title)
+}
+
+// GaugeInt implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) GaugeInt(title string, value int) {
+	ml.logger.GaugeInt(title, value)
+}
+
+// GaugeFloat implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) GaugeFloat(title string, value float64) {
+	ml.logger.GaugeFloat(title, value)
+}
+
+// DebugD implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) DebugD(title string, data map[string]interface{}) {
+	ml.logger.DebugD(title, data)
+}
+
+// InfoD implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) InfoD(title string, data map[string]interface{}) {
+	ml.logger.InfoD(title, data)
+}
+
+// WarnD implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) WarnD(title string, data map[string]interface{}) {
+	ml.logger.WarnD(title, data)
+}
+
+// ErrorD implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) ErrorD(title string, data map[string]interface{}) {
+	ml.logger.ErrorD(title, data)
+}
+
+// CriticalD implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) CriticalD(title string, data map[string]interface{}) {
+	ml.logger.CriticalD(title, data)
+}
+
+// CounterD implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) CounterD(title string, value int, data map[string]interface{}) {
+	ml.logger.CounterD(title, value, data)
+}
+
+// GaugeIntD implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) GaugeIntD(title string, value int, data map[string]interface{}) {
+	ml.logger.GaugeIntD(title, value, data)
+}
+
+// GaugeFloatD implements the method for the KayveeLogger interface.
+// Logs with type = gauge, and value = value
+func (ml *MockRouteCountLogger) GaugeFloatD(title string, value float64, data map[string]interface{}) {
+	ml.logger.GaugeFloatD(title, value, data)
+}
+
+// WithRoutingConfig implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) WithRoutingConfig(filename string) (KayveeLogger, error) {
+	return ml.logger.WithRoutingConfig(filename)
+}

--- a/logger/mocklogger_test.go
+++ b/logger/mocklogger_test.go
@@ -1,0 +1,67 @@
+package logger
+
+import (
+	"testing"
+
+	router "github.com/Clever/kayvee-go/router"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockLoggerImplementsKayveeLogger(t *testing.T) {
+	assert.Implements(t, (*KayveeLogger)(nil), &MockRouteCountLogger{}, "*MockRouteCountLogger should implement KayveeLogger")
+}
+
+func TestRouteCountsWithMockLogger(t *testing.T) {
+	routes := map[string](router.Rule){
+		"rule-one": router.Rule{
+			Matchers: router.RuleMatchers{
+				"foo": []string{"bar", "baz"},
+			},
+			Output: router.RuleOutput{
+				"out": "#-%{foo}-",
+			},
+		},
+		"rule-two": router.Rule{
+			Matchers: router.RuleMatchers{
+				"abc": []string{"def"},
+			},
+			Output: router.RuleOutput{
+				"more": "x",
+			},
+		},
+	}
+	testRouter := router.NewFromRoutes(routes)
+
+	mockLogger := NewMockCountLogger("testing")
+	mockLogger.logger.logRouter = testRouter
+
+	data0 := map[string]interface{}{
+		"wrong": "stuff",
+	}
+	expected0 := map[string]int{}
+	mockLogger.InfoD("log0", data0)
+	actual0 := mockLogger.GetRuleCounts()
+	assert.Equal(t, expected0, actual0)
+
+	data1 := map[string]interface{}{
+		"foo": "bar",
+	}
+	expected1 := map[string]int{
+		"rule-one": 1,
+	}
+	mockLogger.InfoD("log1", data1)
+	actual1 := mockLogger.GetRuleCounts()
+	assert.Equal(t, expected1, actual1)
+
+	data2 := map[string]interface{}{
+		"foo": "bar",
+		"abc": "def",
+	}
+	expected2 := map[string]int{
+		"rule-one": 2,
+		"rule-two": 1,
+	}
+	mockLogger.InfoD("log2", data2)
+	actual2 := mockLogger.GetRuleCounts()
+	assert.Equal(t, expected2, actual2)
+}

--- a/logger/mocklogger_test.go
+++ b/logger/mocklogger_test.go
@@ -3,8 +3,8 @@ package logger
 import (
 	"testing"
 
-	router "github.com/Clever/kayvee-go/router"
 	"github.com/stretchr/testify/assert"
+	router "gopkg.in/Clever/kayvee-go.v5/router"
 )
 
 func TestMockLoggerImplementsKayveeLogger(t *testing.T) {

--- a/logger/mocklogger_test.go
+++ b/logger/mocklogger_test.go
@@ -30,7 +30,8 @@ func TestRouteCountsWithMockLogger(t *testing.T) {
 			},
 		},
 	}
-	testRouter := router.NewFromRoutes(routes)
+	testRouter, err := router.NewFromRoutes(routes)
+	assert.NoError(t, err)
 
 	mockLogger := NewMockCountLogger("testing")
 	mockLogger.logger.logRouter = testRouter

--- a/logger/mocklogger_test.go
+++ b/logger/mocklogger_test.go
@@ -40,7 +40,7 @@ func TestRouteCountsWithMockLogger(t *testing.T) {
 	}
 	expected0 := map[string]int{}
 	mockLogger.InfoD("log0", data0)
-	actual0 := mockLogger.GetRuleCounts()
+	actual0 := mockLogger.RuleCounts()
 	assert.Equal(t, expected0, actual0)
 
 	data1 := map[string]interface{}{
@@ -50,7 +50,7 @@ func TestRouteCountsWithMockLogger(t *testing.T) {
 		"rule-one": 1,
 	}
 	mockLogger.InfoD("log1", data1)
-	actual1 := mockLogger.GetRuleCounts()
+	actual1 := mockLogger.RuleCounts()
 	assert.Equal(t, expected1, actual1)
 
 	data2 := map[string]interface{}{
@@ -62,6 +62,6 @@ func TestRouteCountsWithMockLogger(t *testing.T) {
 		"rule-two": 1,
 	}
 	mockLogger.InfoD("log2", data2)
-	actual2 := mockLogger.GetRuleCounts()
+	actual2 := mockLogger.RuleCounts()
 	assert.Equal(t, expected2, actual2)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -95,3 +95,14 @@ func NewFromRoutes(routes map[string]Rule) (RuleRouter, error) {
 
 	return router, nil
 }
+
+// NewFromRoutes constructs a RuleRouter using the provided map of route names
+// to Rules.
+func NewFromRoutes(routes map[string]Rule) RuleRouter {
+	router := RuleRouter{}
+	for name, rule := range routes {
+		rule.Name = name
+		router.rules = append(router.rules, rule)
+	}
+	return router
+}

--- a/router/router.go
+++ b/router/router.go
@@ -95,14 +95,3 @@ func NewFromRoutes(routes map[string]Rule) (RuleRouter, error) {
 
 	return router, nil
 }
-
-// NewFromRoutes constructs a RuleRouter using the provided map of route names
-// to Rules.
-func NewFromRoutes(routes map[string]Rule) RuleRouter {
-	router := RuleRouter{}
-	for name, rule := range routes {
-		rule.Name = name
-		router.rules = append(router.rules, rule)
-	}
-	return router
-}


### PR DESCRIPTION
**Overview:**
This provides a new mock logger implementation that counts the number of times particular routing rules are used in log routing. This functionality will be very useful for testing log routing configs.

`logger.Logger` has new abstractions at two levels:
1. There is a new exported interface `logger.KayveeLogger` that `logger.Logger` and the new `logger.MockRouteCountLogger` both implement, allowing clients to easily replace `logger.Logger` in their tests (or define/generate their own loggers or mocks).
2. There is a new internal interface `logger.formatLogger` which abstracts the format and output steps of the log writing process. This allows for `MockRouteCountLogger` to lightly wrap a `logger.Logger` (preserving all metadata generated in its many methods), but then replace the format/write stage with computing the statistics.

**Pre-merge:**
- [ ] Before merging to `master`, make sure that a new version hasn't been
  merged. Then, use `make bump-major`, `make bump-minor`, or `make bump-patch`
  to bump the version number in VERSION and version.go (and all files that
  reference gopkg.in if a major bump).

**Post-merge:**
- [ ] After merging to `master`, Use `make tag-version` to set the version
  number in a git tag. Then, run `git push --tags` to push the new tag.
