### PR TITLE
Performance improvements

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,5 +13,6 @@ script:
 - mv `pwd` $GOPATH/src/gopkg.in/Clever/kayvee-go.v5
 - cd $GOPATH/src/gopkg.in/Clever/kayvee-go.v5
 - make test
+- make benchmarks
 publish:
   report_card: {}

--- a/router/parse.go
+++ b/router/parse.go
@@ -3,7 +3,6 @@ package router
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
@@ -89,18 +88,11 @@ func (o *RuleOutput) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	envErrors := []string{}
-	getEnvOrErr := func(key string) string {
-		val := os.Getenv(key)
-		if val == "" {
-			envErrors = append(envErrors, fmt.Sprintf("\tEnvironment variable '%s' not set", key))
-		}
-		return val
+	output, err := substituteEnvVars(rawData)
+	if err != nil {
+		return err
 	}
-	*o = substitute(rawData, `\$`, getEnvOrErr)
-	if len(envErrors) > 0 {
-		return errors.New(strings.Join(envErrors, "\n"))
-	}
+	*o = output
 
 	return nil
 }

--- a/router/substituters.go
+++ b/router/substituters.go
@@ -1,0 +1,73 @@
+package router
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var envvarTokens = regexp.MustCompile(`\$\{.+?\}`)
+var fieldTokens = regexp.MustCompile(`%\{.+?\}`)
+
+// substitute performs a key-value substitution on `obj`, replacing instances
+// of tokenMatcher in the keys or values of `obj` with `replacer(name)`. It
+// returns the substituted map and does not modify the input map.
+func substitute(
+	obj map[string]interface{}, tokenMatcher *regexp.Regexp, replacer func(key string) string,
+) map[string]interface{} {
+	newObj := make(map[string]interface{})
+	for k, v := range obj {
+		switch v := v.(type) {
+		case string:
+			newObj[k] = tokenMatcher.ReplaceAllStringFunc(v, replacer)
+		case []string:
+			newV := make([]string, len(v))
+			for i := 0; i < len(v); i++ {
+				newV[i] = tokenMatcher.ReplaceAllStringFunc(v[i], replacer)
+			}
+			newObj[k] = newV
+		default:
+			newObj[k] = v
+		}
+	}
+	return newObj
+}
+
+func substituteEnvVars(data map[string]interface{}) (map[string]interface{}, error) {
+	envErrors := []string{}
+	getEnvOrErr := func(key string) string {
+		// Performance optimization: slice sub-sequence is faster than regex.FindStringSubmatch
+		key = key[2 : len(key)-1]
+
+		val := os.Getenv(key)
+		if val == "" {
+			envErrors = append(envErrors, fmt.Sprintf("\tEnvironment variable '%s' not set", key))
+		}
+		return val
+	}
+
+	subs := substitute(data, envvarTokens, getEnvOrErr)
+	if len(envErrors) > 0 {
+		return nil, errors.New(strings.Join(envErrors, "\n"))
+	}
+
+	return subs, nil
+}
+
+func substituteFields(
+	data map[string]interface{}, lookup func(string) (string, bool),
+) map[string]interface{} {
+	kvSubber := func(key string) string {
+		// Performance optimization: slice sub-sequence is faster than regex.FindStringSubmatch
+		key = key[2 : len(key)-1]
+
+		if v, ok := lookup(key); ok {
+			return v
+		}
+		return "KEY_NOT_FOUND"
+	}
+
+	return substitute(data, fieldTokens, kvSubber)
+}

--- a/router/substituters.go
+++ b/router/substituters.go
@@ -35,6 +35,9 @@ func substitute(
 	return newObj
 }
 
+// substituteEnvVars performs a key-value substitutions on `data`.  Substituations have the
+// following format: `${ENV_VAR_NAME}`.  Keys are replaced with the corresponding env-var
+// value.  An error is returned if an env-var is not found.
 func substituteEnvVars(data map[string]interface{}) (map[string]interface{}, error) {
 	envErrors := []string{}
 	getEnvOrErr := func(key string) string {
@@ -56,6 +59,10 @@ func substituteEnvVars(data map[string]interface{}) (map[string]interface{}, err
 	return subs, nil
 }
 
+// substituteFields performs a key-value substitutions on `data`.  Substituations have the
+// following format: `%{field-name}`.  Keys are replaced with the corresponding value returned
+// by the `lookup` function.  If lookup doesn't return a value, the text "KEY_NOT_FOUND" is
+// used instead.
 func substituteFields(
 	data map[string]interface{}, lookup func(string) (string, bool),
 ) map[string]interface{} {


### PR DESCRIPTION
Implemented a number of performance improvements.  Nearly all of them were focused on making the substitution code more efficient:

- Regexes are pre-compiled
- Removed capture group from regex
- Replaced `.*` with `.+`
- Replaced instances of `regex.FindStringSubmatch` with direct slice manipulation
- Special cased non-nested fields (i.e. fields without `.`'s)
- Inlined a number of functions (namely the replace / regex functions)

To support these changes, some light refactoring was done.  The substitution code was moved to it's own file.  Also, `substituteEnvVars` and `substituteFields` was created.

![screen shot 2016-11-02 at 3 07 33 pm](https://cloud.githubusercontent.com/assets/75434/19949363/742d7eb6-a10e-11e6-8efe-445e79d3d768.png)

Overall this PR adds a 4x speed increase.  There's still room for improvement.  The pathological case is still 9x slower than the normal case.  At this point, though, I feel all the low hanging fruit have been picked.  More substantial changes to routing would be required to significantly improve performance as far as I can.  The two that come to mind:

- Pre-parse strings with substitutions into an array and use `strings.join` instead of regex replacement
- Instead of looping over possible matched values, insert them into a map for constant look up

I don't think it's worth implementing these changes at the moment.

Context: https://clever.atlassian.net/browse/INFRA-2061
Date: https://docs.google.com/spreadsheets/d/1nOStru7gNPF1ETcJiso4sa9jQTNAp_BhJo1kIz6C5ZI/edit#gid=1641259432