### PR TITLE
Changes to make log-routing WAG compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,10 @@ import (
     "gopkg.in/Clever/kayvee-go.v5/logger"
 )
 
-var log logger.KayveeLogger
+var log = logger.New("myApp")
 
 func init() {
-    var err error
-    log, err = logger.New("myApp").WithRoutingConfig("./kvconfig.yml")
-
+    err := logger.SetGlobalRouting("./kvconfig.yml")
     if err != nil {
         panic(err)
     }
@@ -94,10 +92,8 @@ func TestDataResultsRouting(t *testing.T) {
 
     mocklog := logger.NewMockCountLogger("myApp")
 
-    var err error
     // Overrides package level logger
-    log, err = mocklog.WithRoutingConfig("./kvconfig.yml")
-    assert.NoError(err)
+    log = mocklog
 
     main() // Call function to generate log lines
 

--- a/benchmarks/routing_test.go
+++ b/benchmarks/routing_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"gopkg.in/Clever/kayvee-go.v5/logger"
+	"gopkg.in/Clever/kayvee-go.v5/router"
 )
 
 type logline struct {
@@ -56,18 +57,27 @@ func init() {
 	}
 
 	noRouting = logger.New("perf")
-	basicRouting, err = logger.New("perf").WithRoutingConfig("./data/kvconfig-basic.yml")
+
+	basicRouting = logger.New("perf")
+	basicRouter, err := router.NewFromConfig("./data/kvconfig-basic.yml")
 	if err != nil {
 		log.Fatal(err)
 	}
-	pathoRouting, err = logger.New("perf").WithRoutingConfig("./data/kvconfig-pathological.yml")
+	basicRouting.SetRouter(basicRouter)
+
+	pathoRouting = logger.New("perf")
+	pathoRouter, err := router.NewFromConfig("./data/kvconfig-pathological.yml")
 	if err != nil {
 		log.Fatal(err)
 	}
-	realRouting, err = logger.New("perf").WithRoutingConfig("./data/kvconfig-realistic.yml")
+	pathoRouting.SetRouter(pathoRouter)
+
+	realRouting = logger.New("perf")
+	realRouter, err := router.NewFromConfig("./data/kvconfig-realistic.yml")
 	if err != nil {
 		log.Fatal(err)
 	}
+	realRouting.SetRouter(realRouter)
 
 	output := &noopWriter{}
 	formatter := func(noop map[string]interface{}) string { return "" }

--- a/logger/context.go
+++ b/logger/context.go
@@ -7,7 +7,7 @@ type loggerKeyType struct{}
 var loggerKey = loggerKeyType{}
 
 // NewContext creates a new context object containing a logger value.
-func NewContext(ctx context.Context, logger *Logger) context.Context {
+func NewContext(ctx context.Context, logger KayveeLogger) context.Context {
 	return context.WithValue(ctx, loggerKey, logger)
 }
 
@@ -16,9 +16,9 @@ func NewContext(ctx context.Context, logger *Logger) context.Context {
 // created and returned. This allows users of this method to use the logger
 // immediately, e.g.
 //   logger.FromContext(ctx).Info("...")
-func FromContext(ctx context.Context) *Logger {
+func FromContext(ctx context.Context) KayveeLogger {
 	logger := ctx.Value(loggerKey)
-	if lggr, ok := logger.(*Logger); ok {
+	if lggr, ok := logger.(KayveeLogger); ok {
 		return lggr
 	}
 	return New("")

--- a/logger/kayvee_logger.go
+++ b/logger/kayvee_logger.go
@@ -2,6 +2,8 @@ package logger
 
 import (
 	"io"
+
+	"gopkg.in/Clever/kayvee-go.v5/router"
 )
 
 /////////////////////////////
@@ -32,10 +34,12 @@ type KayveeLogger interface {
 	// SetOutput changes the output destination of the logger
 	SetOutput(output io.Writer)
 
-	// WithRoutingConfig installs a new log router onto the KayveeLogger with the
-	// configuration specified in `filename`. For convenience, the KayveeLogger is expected
-	// to return itself as the first return value.
-	WithRoutingConfig(filename string) (KayveeLogger, error)
+	// setFormatLogger use for to implemente the mock
+	setFormatLogger(fl formatLogger)
+
+	// SetRouter changes the router for this logger instance.  Once set, logs produced by this
+	// logger will not be touched by the global router.  Mostly used for testing and benchmarking.
+	SetRouter(router router.Router)
 
 	//
 	// Logging

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -225,7 +225,9 @@ func TestAddContext(t *testing.T) {
 }
 
 func TestFailAddReservedContext(t *testing.T) {
-	logger := New("logger-tester")
+	logger, ok := New("logger-tester").(*Logger)
+	assert.True(t, ok)
+
 	reservedKeyNames := map[string]bool{
 		"title":  true,
 		"source": true,
@@ -251,8 +253,9 @@ func TestRouter(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := New("logger-tester")
 	logger.SetOutput(buf)
+
 	m := MockRouter{t, false}
-	logger.logRouter = &m
+	logger.SetRouter(&m)
 	logger.InfoD("testloginfo", map[string]interface{}{"key1": "val1", "key2": "val2"})
 	assert.True(t, m.called)
 	expected := kv.FormatLog("logger-tester", kv.Info, "testloginfo", M{

--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -2,12 +2,14 @@ package logger
 
 import (
 	"io"
+
+	"gopkg.in/Clever/kayvee-go.v5/router"
 )
 
 // MockRouteCountLogger is a mock implementation of KayveeLogger that counts the router rules
 // applied to each log call without actually formatting or writing the log line.
 type MockRouteCountLogger struct {
-	logger      *Logger
+	logger      KayveeLogger
 	routeCounts map[string]int
 }
 
@@ -31,9 +33,9 @@ func NewMockCountLogger(source string) *MockRouteCountLogger {
 func NewMockCountLoggerWithContext(source string, contextValues map[string]interface{}) *MockRouteCountLogger {
 	routeCounts := make(map[string]int)
 	lg := NewWithContext(source, contextValues)
-	lg.fLogger = &routeCountingFormatLogger{
+	lg.setFormatLogger(&routeCountingFormatLogger{
 		routeCounts: routeCounts,
-	}
+	})
 	mocklg := MockRouteCountLogger{
 		logger:      lg,
 		routeCounts: routeCounts,
@@ -111,6 +113,16 @@ func (ml *MockRouteCountLogger) SetFormatter(formatter Formatter) {
 // SetOutput implements the method for the KayveeLogger interface.
 func (ml *MockRouteCountLogger) SetOutput(output io.Writer) {
 	ml.logger.SetOutput(output)
+}
+
+// setFormatLogger implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) setFormatLogger(output formatLogger) {
+	return // Mocks need a custom format logger
+}
+
+// SetRouter implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) SetRouter(router router.Router) {
+	ml.logger.SetRouter(router)
 }
 
 // Debug implements the method for the KayveeLogger interface.
@@ -192,9 +204,4 @@ func (ml *MockRouteCountLogger) GaugeIntD(title string, value int, data map[stri
 // Logs with type = gauge, and value = value
 func (ml *MockRouteCountLogger) GaugeFloatD(title string, value float64, data map[string]interface{}) {
 	ml.logger.GaugeFloatD(title, value, data)
-}
-
-// WithRoutingConfig implements the method for the KayveeLogger interface.
-func (ml *MockRouteCountLogger) WithRoutingConfig(filename string) (KayveeLogger, error) {
-	return ml.logger.WithRoutingConfig(filename)
 }

--- a/logger/mocklogger_test.go
+++ b/logger/mocklogger_test.go
@@ -34,7 +34,7 @@ func TestRouteCountsWithMockLogger(t *testing.T) {
 	assert.NoError(t, err)
 
 	mockLogger := NewMockCountLogger("testing")
-	mockLogger.logger.logRouter = testRouter
+	mockLogger.SetRouter(testRouter)
 
 	data0 := map[string]interface{}{
 		"wrong": "stuff",

--- a/router/parse_test.go
+++ b/router/parse_test.go
@@ -78,7 +78,9 @@ routes:
 	router, err := newFromConfigBytes(conf)
 	assert.Nil(t, err)
 
-	actual := SortableRules(router.rules)
+	r, ok := router.(*RuleRouter)
+	assert.True(t, ok)
+	actual := SortableRules(r.rules)
 	sort.Sort(expected)
 	sort.Sort(actual)
 	assert.Equal(t, expected, actual)

--- a/router/router.go
+++ b/router/router.go
@@ -27,7 +27,7 @@ func init() {
 // Route returns routing metadata for the log line `msg`. The outputs (with
 // variable substitutions performed) for each rule matched are placed under the
 // "routes" key.
-func (r RuleRouter) Route(msg map[string]interface{}) map[string]interface{} {
+func (r *RuleRouter) Route(msg map[string]interface{}) map[string]interface{} {
 	outputs := []map[string]interface{}{}
 	for _, rule := range r.rules {
 		if rule.Matches(msg) {
@@ -69,10 +69,10 @@ func NewFromConfig(filename string) (Router, error) {
 	return router, nil
 }
 
-func newFromConfigBytes(fileBytes []byte) (RuleRouter, error) {
+func newFromConfigBytes(fileBytes []byte) (Router, error) {
 	routes, err := parse(fileBytes)
 	if err != nil {
-		return RuleRouter{}, err
+		return &RuleRouter{}, err
 	}
 
 	return NewFromRoutes(routes)
@@ -80,8 +80,8 @@ func newFromConfigBytes(fileBytes []byte) (RuleRouter, error) {
 
 // NewFromRoutes constructs a RuleRouter using the provided map of route names
 // to Rules.
-func NewFromRoutes(routes map[string]Rule) (RuleRouter, error) {
-	router := RuleRouter{}
+func NewFromRoutes(routes map[string]Rule) (Router, error) {
+	router := &RuleRouter{}
 	for name, rule := range routes {
 		output, err := substituteEnvVars(rule.Output)
 		if err != nil {


### PR DESCRIPTION
- Added a package level function called `SetGlobalRouting`
- Added `SetRouter` and `setFormatLogger` to the `KayveeLogger` interface for testing/mocking purposes
- Made more things use KayveeLogger instead `*logger.Logger`