### PR TITLE
Removed app-name from kayvee meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ func main() {
     log.GaugeFloat("QueryTime", time.Since(query_start).Seconds())
 
     // Output structured data
-    log.InfoD("DataResults", logger.M{"key": "value"})
+    log.InfoD("DataResults", logger.M{"key": "value"})  // Sends slack message (see Log Routing)
 
     // You can use the M alias for your key value pairs
-    log.InfoD("DataResults", logger.M{"shorter": "line"})
+    log.InfoD("DataResults", logger.M{"shorter": "line"}) // will NOT send slack message
 }
 ```
 

--- a/router/router.go
+++ b/router/router.go
@@ -8,16 +8,9 @@ import (
 	kv "gopkg.in/Clever/kayvee-go.v5"
 )
 
-var (
-	appName  string
-	teamName string
-)
+var teamName string
 
 func init() {
-	appName = os.Getenv("_APP_NAME")
-	if appName == "" {
-		appName = "UNSET"
-	}
 	teamName = os.Getenv("_TEAM_OWNER")
 	if teamName == "" {
 		teamName = "UNSET"
@@ -35,7 +28,6 @@ func (r *RuleRouter) Route(msg map[string]interface{}) map[string]interface{} {
 		}
 	}
 	return map[string]interface{}{
-		"app":         appName,
 		"team":        teamName,
 		"kv_version":  kv.Version,
 		"kv_language": "go",


### PR DESCRIPTION
This information is redundant with `container_app`.  Also added clarifying comments to README.