### PR TITLE
logger/mocklogger- capture actual routed logs

### DIFF
--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -9,8 +9,8 @@ import (
 // MockRouteCountLogger is a mock implementation of KayveeLogger that counts the router rules
 // applied to each log call without actually formatting or writing the log line.
 type MockRouteCountLogger struct {
-	logger      KayveeLogger
-	routeCounts map[string]int
+	logger       KayveeLogger
+	routeMatches map[string][]M
 }
 
 // RuleCounts returns a map of rule names to the number of times that rule has been applied
@@ -18,7 +18,17 @@ type MockRouteCountLogger struct {
 // one use.
 func (ml *MockRouteCountLogger) RuleCounts() map[string]int {
 	out := make(map[string]int)
-	for k, v := range ml.routeCounts {
+	for k, v := range ml.routeMatches {
+		out[k] = len(v)
+	}
+	return out
+}
+
+// RuleMatches returns a map of rule names to the exact logs which matched that rule (after routing has
+// been applied to those logs). This allows you to inspect the routed log and verify data about it.
+func (ml *MockRouteCountLogger) RuleMatches() map[string][]M {
+	out := make(map[string][]M)
+	for k, v := range ml.routeMatches {
 		out[k] = v
 	}
 	return out
@@ -31,14 +41,14 @@ func NewMockCountLogger(source string) *MockRouteCountLogger {
 
 // NewMockCountLoggerWithContext returns a new MockRoutCountLogger with the specified `source` and `contextValues`.
 func NewMockCountLoggerWithContext(source string, contextValues map[string]interface{}) *MockRouteCountLogger {
-	routeCounts := make(map[string]int)
+	routeMatches := make(map[string][]M)
 	lg := NewWithContext(source, contextValues)
 	lg.setFormatLogger(&routeCountingFormatLogger{
-		routeCounts: routeCounts,
+		routeMatches: routeMatches,
 	})
 	mocklg := MockRouteCountLogger{
-		logger:      lg,
-		routeCounts: routeCounts,
+		logger:       lg,
+		routeMatches: routeMatches,
 	}
 	return &mocklg
 }
@@ -52,7 +62,7 @@ func NewMockCountLoggerWithContext(source string, contextValues map[string]inter
 // routeCountingFormatLogger implements the formatLogger interface to allow for counting
 // invocations of routing rules.
 type routeCountingFormatLogger struct {
-	routeCounts map[string]int
+	routeMatches map[string][]M
 }
 
 // formatAndLog tracks routing statistics for this mock router.
@@ -68,7 +78,7 @@ func (fl *routeCountingFormatLogger) formatAndLog(data map[string]interface{}) {
 	}
 	for _, route := range routes.([]map[string]interface{}) {
 		rule := route["rule"].(string)
-		fl.routeCounts[rule] = fl.routeCounts[rule] + 1
+		fl.routeMatches[rule] = append(fl.routeMatches[rule], data)
 	}
 }
 

--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -24,12 +24,20 @@ func (ml *MockRouteCountLogger) RuleCounts() map[string]int {
 	return out
 }
 
-// RuleMatches returns a map of rule names to the exact logs which matched that rule (after routing has
+// RuleOutputs returns a map of rule names to the exact logs which matched that rule (after routing has
 // been applied to those logs). This allows you to inspect the routed log and verify data about it.
-func (ml *MockRouteCountLogger) RuleMatches() map[string][]M {
-	out := make(map[string][]M)
-	for k, v := range ml.routeMatches {
-		out[k] = v
+func (ml *MockRouteCountLogger) RuleOutputs() map[string][]router.RuleOutput {
+	out := make(map[string][]router.RuleOutput)
+	for rule, matchingLogs := range ml.routeMatches {
+		for _, l := range matchingLogs {
+			routes := l["_kvmeta"].(map[string]interface{})["routes"].([]map[string]interface{})
+			for _, route := range routes {
+				if route["rule"].(string) == rule {
+					out[rule] = append(out[rule], route)
+					break
+				}
+			}
+		}
 	}
 	return out
 }

--- a/logger/mocklogger_test.go
+++ b/logger/mocklogger_test.go
@@ -48,9 +48,9 @@ func TestRouteCountsWithMockLogger(t *testing.T) {
 	assert.Equal(t, expectedCounts0, actualCounts0)
 
 	t.Log("log0 -- verify rule matches")
-	actualMatches0 := mockLogger.RuleMatches()
-	expectedMatches0 := map[string][]M{}
-	assert.Equal(t, expectedMatches0, actualMatches0)
+	actualRoutes0 := mockLogger.RuleOutputs()
+	expectedRoutes0 := map[string][]router.RuleOutput{}
+	assert.Equal(t, expectedRoutes0, actualRoutes0)
 
 	t.Log("log1")
 	data1 := M{
@@ -64,33 +64,20 @@ func TestRouteCountsWithMockLogger(t *testing.T) {
 	assert.Equal(t, expectedCounts1, actualCounts1)
 
 	t.Log("log1 -- verify rule matches")
-	expectedRoutedLog1 := M{
-		"foo":        "bar",
-		"source":     "testing",
-		"title":      "log1",
-		"level":      "info",
-		"deploy_env": "testing",
-		"_kvmeta": map[string]interface{}{
-			"kv_language": "go",
-			"kv_version":  "6.2.0",
-			"team":        "UNSET",
-			"routes": []map[string]interface{}{
-				map[string]interface{}{
-					"rule": "rule-one",
-					"out":  "#-bar-",
-				},
+	actualRoutes1 := mockLogger.RuleOutputs()
+	expectedRoutes1 := map[string][]router.RuleOutput{
+		"rule-one": []router.RuleOutput{
+			router.RuleOutput{
+				"rule": "rule-one",
+				"out":  "#-bar-",
 			},
 		},
 	}
-	actualMatches1 := mockLogger.RuleMatches()
-	expectedMatches1 := map[string][]M{
-		"rule-one": []M{expectedRoutedLog1},
-	}
-	assert.Equal(t, expectedMatches1, actualMatches1)
+	assert.Equal(t, expectedRoutes1, actualRoutes1)
 
 	t.Log("log2")
 	data2 := M{
-		"foo": "bar",
+		"foo": "baz",
 		"abc": "def",
 	}
 	mockLogger.InfoD("log2", data2)
@@ -104,39 +91,26 @@ func TestRouteCountsWithMockLogger(t *testing.T) {
 	assert.Equal(t, expectedCounts2, actualCounts2)
 
 	t.Log("log2 -- verify rule matches")
-	expectedRoutedLog2 := M{
-		"foo":        "bar",
-		"abc":        "def",
-		"source":     "testing",
-		"title":      "log2",
-		"level":      "info",
-		"deploy_env": "testing",
-		"_kvmeta": map[string]interface{}{
-			"kv_language": "go",
-			"kv_version":  "6.2.0",
-			"team":        "UNSET",
-			"routes": []map[string]interface{}{
-				map[string]interface{}{
-					"rule": "rule-one",
-					"out":  "#-bar-",
-				},
-				map[string]interface{}{
-					"rule": "rule-two",
-					"more": "x",
-				},
+
+	expectedRoutes2 := map[string][]router.RuleOutput{
+		"rule-one": []router.RuleOutput{
+			router.RuleOutput{
+				"rule": "rule-one",
+				"out":  "#-bar-",
+			},
+			router.RuleOutput{
+				"rule": "rule-one",
+				"out":  "#-baz-",
+			},
+		},
+		"rule-two": []router.RuleOutput{
+			router.RuleOutput{
+				"rule": "rule-two",
+				"more": "x",
 			},
 		},
 	}
-	expectedMatches2 := map[string][]M{
-		"rule-one": []M{
-			expectedRoutedLog1,
-			expectedRoutedLog2,
-		},
-		"rule-two": []M{
-			expectedRoutedLog2,
-		},
-	}
 
-	actualMatches2 := mockLogger.RuleMatches()
-	assert.Equal(t, expectedMatches2, actualMatches2)
+	actualRoutes2 := mockLogger.RuleOutputs()
+	assert.Equal(t, expectedRoutes2, actualRoutes2)
 }

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 package kayvee
 
 // Version is a string containing the version of this library.
-var Version = "6.2.0"
+var Version = "6.3.0"


### PR DESCRIPTION
Issue: https://clever.atlassian.net/browse/INFRA-2101

**Overview:**

By using the `RuleOutputs()` method, a user can now test the exact rule matched by a log (including data interpolated into the rule).

This can be useful if you want to e.g. verify whether or not an env var
was properly rendered into your output data.

--

**Pre-merge:**
- [x] Before merging to `master`, make sure that a new version hasn't been
  merged. Then, use `make bump-major`, `make bump-minor`, or `make bump-patch`
  to bump the version number in VERSION and version.go (and all files that
  reference gopkg.in if a major bump).

**Post-merge:**
- [ ] After merging to `master`, Use `make tag-version` to set the version
  number in a git tag. Then, run `git push --tags` to push the new tag.
