### PR TITLE
update link for log routing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ routes:
       user: "The Data Duck"
 ```
 
-For more information see https://clever.atlassian.net/wiki/display/ENG/Log+Routing
+For more information see https://clever.atlassian.net/wiki/display/ENG/Application+Log+Routing
 
 ## Testing
 


### PR DESCRIPTION
**Overview:**

Current link for log routing documentation is dead. This PR updates to what looks like the new link - [https://clever.atlassian.net/wiki/display/ENG/Application+Log+Routing](https://clever.atlassian.net/wiki/display/ENG/Application+Log+Routing).

**Pre-merge:**
- [ ] Before merging to `master`, make sure that a new version hasn't been
  merged. Then, use `make bump-major`, `make bump-minor`, or `make bump-patch`
  to bump the version number in VERSION and version.go (and all files that
  reference gopkg.in if a major bump).

**Post-merge:**
- [ ] After merging to `master`, Use `make tag-version` to set the version
  number in a git tag. Then, run `git push --tags` to push the new tag.
