### PR TITLE
WIP/POC: log rollup output

### DIFF
--- a/embeddedoutputs/logrollup.go
+++ b/embeddedoutputs/logrollup.go
@@ -1,0 +1,199 @@
+package embeddedoutputs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// InfoD is what the rollup uses to output rollup info.
+type InfoD interface {
+	InfoD(title string, data map[string]interface{})
+}
+
+// InfoDCreator is a function that returns an InfoD.
+// Every rollup is configured with a source + title string, and InfoD will log them.
+type InfoDCreator func(source string) InfoD
+
+// LogRollupOutput rolls up log lines and periodically logs them as one log line.
+type LogRollupOutput struct {
+	infoDCreator InfoDCreator
+	ctx          context.Context
+
+	rollupsMu sync.Mutex
+	rollups   map[string]*logRollup
+}
+
+// NewLogRollupOutput creates a new log rollup output.
+func NewLogRollupOutput(infoDCreator InfoDCreator) *LogRollupOutput {
+	return &LogRollupOutput{
+		infoDCreator: infoDCreator,
+		rollups:      map[string]*logRollup{},
+		ctx:          context.Background(),
+	}
+}
+
+// WithContext adds a context to the log rollup output. All rollups will stop reporting
+// when the context is canceled.
+func (r *LogRollupOutput) WithContext(ctx context.Context) *LogRollupOutput {
+	r.ctx = ctx
+	return r
+}
+
+// Process a message rollup.
+func (r *LogRollupOutput) Process(data, config map[string]interface{}) error {
+	rollup, err := r.findOrCreate(data, config)
+	if err != nil {
+		return err
+	}
+	rollup.add(data)
+	return nil
+}
+
+type logRollupConfig struct {
+	Name       string
+	Source     string
+	Title      string
+	Dimensions []string
+}
+
+func parseLogRollupConfig(config map[string]interface{}) (*logRollupConfig, error) {
+	var name, source, title string
+	var dimensions []string
+
+	if nameI, ok := config["rule"]; !ok {
+		return nil, errors.New("rollup doesn't have name")
+	} else if nameString, ok := nameI.(string); !ok {
+		return nil, errors.New("rollup name is not a string")
+	} else {
+		name = nameString
+	}
+
+	if sourceI, ok := config["source"]; !ok {
+		return nil, errors.New("rollup doesn't have source")
+	} else if sourceString, ok := sourceI.(string); !ok {
+		return nil, errors.New("rollup source is not a string")
+	} else {
+		source = sourceString
+	}
+
+	if titleI, ok := config["title"]; !ok {
+		return nil, errors.New("rollup doesn't have title")
+	} else if titleString, ok := titleI.(string); !ok {
+		return nil, errors.New("rollup title is not a string")
+	} else {
+		title = titleString
+	}
+
+	if dimensionsI, ok := config["dimensions"]; !ok {
+		return nil, errors.New("rollup doesn't have dimensions")
+	} else if dimensionsArray, ok := dimensionsI.([]interface{}); !ok {
+		return nil, errors.New("rollup dimensions is not an interface array")
+	} else {
+		for _, dimI := range dimensionsArray {
+			dimensions = append(dimensions, dimI.(string))
+		}
+	}
+
+	return &logRollupConfig{
+		Name:       name,
+		Source:     source,
+		Title:      title,
+		Dimensions: dimensions,
+	}, nil
+}
+
+func (r *LogRollupOutput) findOrCreate(data, config map[string]interface{}) (*logRollup, error) {
+	logRollupConfig, err := parseLogRollupConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	rollupKey := logRollupConfig.Name
+	for _, dim := range logRollupConfig.Dimensions {
+		dimV, ok := data[dim]
+		if !ok {
+			return nil, fmt.Errorf("could not find dimension %s in log data", dim)
+		}
+		rollupKey += fmt.Sprintf("-%s", dimV)
+	}
+
+	r.rollupsMu.Lock()
+	defer r.rollupsMu.Unlock()
+	if rollup, ok := r.rollups[rollupKey]; ok {
+		return rollup, nil
+	}
+	rollup := &logRollup{
+		Logger:           r.infoDCreator(logRollupConfig.Source),
+		Name:             logRollupConfig.Name,
+		Title:            logRollupConfig.Title,
+		Dimensions:       logRollupConfig.Dimensions,
+		ReportingDelayNs: (time.Second * 20).Nanoseconds(), // todo: make configurable
+	}
+	r.rollups[rollupKey] = rollup
+	go rollup.schedule(r.ctx)
+	return rollup, nil
+}
+
+// logRollup represents a single rollup.
+type logRollup struct {
+	Logger           InfoD
+	Name             string
+	Title            string
+	Dimensions       []string
+	ReportingDelayNs int64
+
+	rollupMsgMu sync.Mutex
+	rollupMsg   map[string]interface{}
+}
+
+func (r *logRollup) report() {
+	r.rollupMsgMu.Lock()
+	defer r.rollupMsgMu.Unlock()
+	if r.rollupMsg != nil {
+		r.Logger.InfoD(r.Name, r.rollupMsg)
+	}
+	r.rollupMsg = nil
+}
+
+func (r *logRollup) schedule(ctx context.Context) {
+	lastReport := time.Now()
+	for {
+		reportingDelay := time.Duration(atomic.LoadInt64(&r.ReportingDelayNs))
+		wakeupTime := lastReport.Add(reportingDelay)
+		now := time.Now()
+		if now.After(wakeupTime) {
+			wakeupTime = now.Add(reportingDelay)
+		}
+		sleepTime := wakeupTime.Sub(now)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(sleepTime):
+			lastReport = time.Now()
+			r.report()
+		}
+	}
+}
+
+func (r *logRollup) add(msg map[string]interface{}) {
+	r.rollupMsgMu.Lock()
+	defer r.rollupMsgMu.Unlock()
+
+	if r.rollupMsg == nil {
+		r.rollupMsg = map[string]interface{}{
+			"count": int64(0),
+		}
+	}
+
+	r.rollupMsg["count"] = r.rollupMsg["count"].(int64) + 1
+	// TODO: allow users to perform additional numeric rollups, e.g. if there's a field `response-time`, let them average it
+
+	for _, dim := range r.Dimensions {
+		r.rollupMsg[dim] = msg[dim]
+	}
+}

--- a/embeddedoutputs/outputs.go
+++ b/embeddedoutputs/outputs.go
@@ -1,0 +1,54 @@
+package embeddedoutputs
+
+import "errors"
+
+// Output is a destination you'd like to send log data to.
+type Output interface {
+	Process(data, config map[string]interface{}) error
+}
+
+var (
+	logRollupOutputName   = "log-rollup"
+	globalLogRollupOutput = (Output)(nil)
+)
+
+func embeddedOutput(outputName string) bool {
+	switch outputName {
+	case logRollupOutputName:
+		return true
+	}
+	return false
+}
+
+// InitLogRollupOutput must be called before routing logs to the log rollup output.
+func InitLogRollupOutput(logRollupOutput *LogRollupOutput) {
+	globalLogRollupOutput = logRollupOutput
+}
+
+// Route a log to an embedded output, if specificed in the routing data in _kvmeta.
+func Route(data map[string]interface{}) (bool, error) {
+	routed := false
+	if kvmeta, ok := data["_kvmeta"].(map[string]interface{}); ok {
+		for _, output := range kvmeta["routes"].([]map[string]interface{}) {
+			outputType, ok := output["type"].(string)
+			if ok && embeddedOutput(outputType) {
+				routed = true
+				if err := callEmbeddedOutput(outputType, data, output); err != nil {
+					return routed, err
+				}
+			}
+		}
+	}
+	return routed, nil
+}
+
+func callEmbeddedOutput(outputType string, data, config map[string]interface{}) error {
+	switch outputType {
+	case logRollupOutputName:
+		if globalLogRollupOutput == nil {
+			return errors.New("must call InitLogRollupOutput")
+		}
+		return globalLogRollupOutput.Process(data, config)
+	}
+	return nil
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	kv "gopkg.in/Clever/kayvee-go.v6"
+	"gopkg.in/Clever/kayvee-go.v6/embeddedoutputs"
 	"gopkg.in/Clever/kayvee-go.v6/router"
 )
 
@@ -255,7 +256,16 @@ func (l *Logger) logWithLevel(logLvl LogLevel, data map[string]interface{}) {
 		data["_kvmeta"] = globalRouter.Route(data)
 	}
 
-	l.fLogger.formatAndLog(data)
+	// call any embedded outputs
+	routedLocally, err := embeddedoutputs.Route(data)
+	if err != nil {
+		l.ErrorD("embedded-output-error", map[string]interface{}{"error": err.Error()})
+		return
+	}
+
+	if !routedLocally {
+		l.fLogger.formatAndLog(data)
+	}
 }
 
 // updateContextMapIfNotReserved updates context[key] to val if key is not in the reserved list.

--- a/router/schema_definitions.json
+++ b/router/schema_definitions.json
@@ -36,8 +36,24 @@
         { "$ref": "#/definitions/metricsOutput" },
         { "$ref": "#/definitions/alertsOutput" },
         { "$ref": "#/definitions/analyticsOutput" },
-        { "$ref": "#/definitions/notificationsOutput" }
+        { "$ref": "#/definitions/notificationsOutput" },
+        { "$ref": "#/definitions/rollupOutput" }
       ]
+    },
+    "rollupOutput": {
+      "title": "Rollup Output",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "source", "title", "dimensions"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^log-rollup$"
+        },
+        "source": { "type": "string" },
+        "title": { "type": "string" },
+        "dimensions": { "$ref": "#/definitions/flatValueArr" }
+      }
     },
     "metricsOutput": {
       "title": "Metrics Output",

--- a/router/schema_gen.go
+++ b/router/schema_gen.go
@@ -40,8 +40,24 @@ var routerSchema = `{
         { "$ref": "#/definitions/metricsOutput" },
         { "$ref": "#/definitions/alertsOutput" },
         { "$ref": "#/definitions/analyticsOutput" },
-        { "$ref": "#/definitions/notificationsOutput" }
+        { "$ref": "#/definitions/notificationsOutput" },
+        { "$ref": "#/definitions/rollupOutput" }
       ]
+    },
+    "rollupOutput": {
+      "title": "Rollup Output",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "source", "title", "dimensions"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^log-rollup$"
+        },
+        "source": { "type": "string" },
+        "title": { "type": "string" },
+        "dimensions": { "$ref": "#/definitions/flatValueArr" }
+      }
     },
     "metricsOutput": {
       "title": "Metrics Output",


### PR DESCRIPTION
**Overview:**

We currently generate a lot of duplicate / trivial logs. This is a proof of concept that

- Creates a new class of "embedded" outputs available for application-side log routing. These outputs are called in the client instead of later on in the log pipeline
- Adds a `log-rollup` output that receives log data and occasionally rolls it up

Demo:
See this app-service branch: https://github.com/Clever/app-service/compare/poc-request-finished-rollup

Slam it with requests

See rollups:

```
Thu 18:23:03.801 app-service/local> { source.title=app-service.request-finished-rollup, count:91, deploy_env:"local", path:"/", status-code:404 }
Thu 18:23:03.826 app-service/local> { source.title=app-service.request-finished-rollup, count:90, deploy_env:"local", path:"/_health", status-code:200 }
```


