### PR TITLE
fix op rollup

### DIFF
--- a/logger/kayvee_logger.go
+++ b/logger/kayvee_logger.go
@@ -22,6 +22,9 @@ type KayveeLogger interface {
 	// AddContext adds a new key-val to be logged with all log messages.
 	AddContext(key, val string)
 
+	// GetContext reads a key-val from the global map of data that will be logged with all log messages.
+	GetContext(key string) (interface{}, bool)
+
 	// SetConfig allows configuration changes in one go
 	SetConfig(source string, logLvl LogLevel, formatter Formatter, output io.Writer)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -109,6 +109,12 @@ func (l *Logger) AddContext(key, val string) {
 	updateContextMapIfNotReserved(l.globals, key, val)
 }
 
+// GetContext implements the method for the KayveeLogger interface.
+func (l *Logger) GetContext(key string) (interface{}, bool) {
+	val, ok := l.globals[key]
+	return val, ok
+}
+
 // SetRouter implements the method for the KayveeLogger interface.
 func (l *Logger) SetRouter(router router.Router) {
 	l.logRouter = router

--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -106,6 +106,11 @@ func (ml *MockRouteCountLogger) AddContext(key, val string) {
 	ml.logger.AddContext(key, val)
 }
 
+// GetContext implements the method for the KayveeLogger interface.
+func (ml *MockRouteCountLogger) GetContext(key string) (interface{}, bool) {
+	return ml.logger.GetContext(key)
+}
+
 // SetLogLevel implements the method for the KayveeLogger interface.
 func (ml *MockRouteCountLogger) SetLogLevel(logLvl LogLevel) {
 	ml.logger.SetLogLevel(logLvl)

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -18,12 +18,19 @@ import (
 )
 
 var defaultHandler = func(req *http.Request) map[string]interface{} {
-	return map[string]interface{}{
+	data := map[string]interface{}{
 		"method": req.Method,
 		"path":   req.URL.Path,
 		"params": req.URL.RawQuery,
 		"ip":     getIP(req),
 	}
+
+	// TODO: wag should inject metadata into the req context
+	// Then we wouldn't need to expose logger globals via GetContext
+	if op, ok := logger.FromContext(req.Context()).GetContext("op"); ok {
+		data["op"] = op
+	}
+	return data
 }
 
 type logHandler struct {


### PR DESCRIPTION
`op` exists in the global context map of the logger. In order to roll up on this we need to extract it from that. See my comment, but I think the proper mechanism for this would be for `wag` to inject metadata into the `req` context object, and for middleware to read that.
