### PR TITLE
instrument logs with pod information

### DIFF
--- a/kayvee.go
+++ b/kayvee.go
@@ -8,6 +8,9 @@ import (
 
 var deployEnv string
 var workflowID string
+var podID string
+var podRegion string
+var podAccount string
 
 func init() {
 	if os.Getenv("_DEPLOY_ENV") != "" {
@@ -15,6 +18,15 @@ func init() {
 	}
 	if os.Getenv("_EXECUTION_NAME") != "" {
 		workflowID = os.Getenv("_EXECUTION_NAME")
+	}
+	if os.Getenv("_POD_ID") != "" {
+		podID = os.Getenv("_POD_ID")
+	}
+	if os.Getenv("_POD_REGION") != "" {
+		podRegion = os.Getenv("_POD_REGION")
+	}
+	if os.Getenv("_POD_ACCOUNT") != "" {
+		podAccount = os.Getenv("_POD_ACCOUNT")
 	}
 }
 
@@ -45,6 +57,15 @@ func Format(data map[string]interface{}) string {
 	}
 	if workflowID != "" {
 		data["wf_id"] = workflowID
+	}
+	if podID != "" {
+		data["pod-id"] = podID
+	}
+	if podRegion != "" {
+		data["pod-region"] = podRegion
+	}
+	if podAccount != "" {
+		data["pod-account"] = podAccount
 	}
 	formattedString, _ := json.Marshal(data)
 	return string(formattedString)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -325,6 +325,15 @@ func NewWithContext(source string, contextValues map[string]interface{}) KayveeL
 	if os.Getenv("_EXECUTION_NAME") != "" {
 		context["wf_id"] = os.Getenv("_EXECUTION_NAME")
 	}
+	if os.Getenv("_POD_ID") != "" {
+		context["pod-id"] = os.Getenv("_POD_ID")
+	}
+	if os.Getenv("_POD_REGION") != "" {
+		context["pod-region"] = os.Getenv("_POD_REGION")
+	}
+	if os.Getenv("_POD_ACCOUNT") != "" {
+		context["pod-account"] = os.Getenv("_POD_ACCOUNT")
+	}
 	logObj := Logger{
 		globals: context,
 	}


### PR DESCRIPTION
**Overview:**: https://clever.atlassian.net/browse/INFRA-3363

The multipod deploy backend in catapult adds a few new environment variables that will be useful when searching logs: the pod ID, the AWS region, and the AWS account where the pod is running. This PR changes kayvee to log these values.

**Pre-merge:**
- [ ] Before merging to `master`, make sure that a new version hasn't been
  merged. Then, use `make bump-major`, `make bump-minor`, or `make bump-patch`
  to bump the version number in VERSION and version.go (and all files that
  reference gopkg.in if a major bump).

**Post-merge:**
- [ ] After merging to `master`, Use `make tag-version` to set the version
  number in a git tag. Then, run `git push --tags` to push the new tag.
