### PR TITLE
move analytics logger to separate package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -150,6 +150,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "effc096622d963cfab1ef63bc375a63e282db439a1cb3135d86b41aa2712479a"
+  inputs-digest = "3bfe3f640cc11acd4180afc4272b5da252ead6a4232e6fc8dc6668a1a660f771"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/logger/analytics/analyticslogger_test.go
+++ b/logger/analytics/analyticslogger_test.go
@@ -1,4 +1,4 @@
-package logger
+package analytics
 
 import (
 	"testing"
@@ -6,18 +6,19 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	gomock "github.com/golang/mock/gomock"
+	"gopkg.in/Clever/kayvee-go.v6/logger"
 )
 
-func TestAnalyticsLogger(t *testing.T) {
+func TestLogger(t *testing.T) {
 	tests := []struct {
 		name             string
-		alc              AnalyticsLoggerConfig
+		alc              Config
 		mockExpectations func(mf *MockFirehoseAPI)
-		ops              func(l KayveeLogger)
+		ops              func(l logger.KayveeLogger)
 	}{
 		{
 			name: "sends one log",
-			alc: AnalyticsLoggerConfig{
+			alc: Config{
 				Environment: "testenv",
 				DBName:      "testdb",
 			},
@@ -28,8 +29,8 @@ func TestAnalyticsLogger(t *testing.T) {
 `)},
 				})
 			},
-			ops: func(l KayveeLogger) {
-				l.InfoD("test-title", M{"foo": "bar"})
+			ops: func(l logger.KayveeLogger) {
+				l.InfoD("test-title", logger.M{"foo": "bar"})
 			},
 		},
 	}
@@ -42,7 +43,7 @@ func TestAnalyticsLogger(t *testing.T) {
 				tt.mockExpectations(mf)
 			}
 			tt.alc.FirehoseAPI = mf
-			al, err := NewAnalyticsLogger(tt.alc)
+			al, err := New(tt.alc)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Noticed when upgrading kv in a repo that I was now pulling in the
aws-sdk, which doesn't seem ideal.

This is technically a breaking change but I think since usage is just
starting we can publish this as a minor bump.
