### PR TITLE
Add batching to analytics logger

### DIFF
--- a/logger/analytics/analyticslogger_test.go
+++ b/logger/analytics/analyticslogger_test.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/firehose"
@@ -51,6 +52,8 @@ func TestLogger(t *testing.T) {
 			}
 			tt.ops(al)
 			al.Close()
+			// sleep to make sure goroutines have time to complete
+			time.Sleep(time.Millisecond)
 		})
 	}
 }

--- a/logger/analytics/analyticslogger_test.go
+++ b/logger/analytics/analyticslogger_test.go
@@ -23,11 +23,13 @@ func TestLogger(t *testing.T) {
 				DBName:      "testdb",
 			},
 			mockExpectations: func(mf *MockFirehoseAPI) {
-				mf.EXPECT().PutRecord(&firehose.PutRecordInput{
+				mf.EXPECT().PutRecordBatch(&firehose.PutRecordBatchInput{
 					DeliveryStreamName: aws.String("testenv--testdb"),
-					Record: &firehose.Record{Data: []byte(`{"foo":"bar"}
+					Records: []*firehose.Record{
+						&firehose.Record{Data: []byte(`{"foo":"bar"}
 `)},
-				})
+					},
+				}).Return(&firehose.PutRecordBatchOutput{FailedPutCount: aws.Int64(0)}, nil)
 			},
 			ops: func(l logger.KayveeLogger) {
 				l.InfoD("test-title", logger.M{"foo": "bar"})
@@ -48,6 +50,7 @@ func TestLogger(t *testing.T) {
 				t.Fatal(err)
 			}
 			tt.ops(al)
+			al.Close()
 		})
 	}
 }

--- a/logger/analytics/analyticslogger_test.go
+++ b/logger/analytics/analyticslogger_test.go
@@ -2,7 +2,6 @@ package analytics
 
 import (
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/firehose"
@@ -52,8 +51,6 @@ func TestLogger(t *testing.T) {
 			}
 			tt.ops(al)
 			al.Close()
-			// sleep to make sure goroutines have time to complete
-			time.Sleep(time.Millisecond)
 		})
 	}
 }


### PR DESCRIPTION
Adds batching in order to

(1) avoid request rate limit and increase max throughput
(2) make analytics logging more-often-than-not non-blocking