### PR TITLE
support environment-variable override of firehose endpoint

### DIFF
--- a/logger/analytics/endpointresolver.go
+++ b/logger/analytics/endpointresolver.go
@@ -1,0 +1,36 @@
+package analytics
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+)
+
+// reNotGoodEnvVarChars is a negated character set of characters that are good
+// to appear in environment variables.
+var reNotGoodEnvVarChars = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+
+func toEnvVar(s string) string {
+	return strings.ToUpper(reNotGoodEnvVarChars.ReplaceAllString(s, "_"))
+}
+
+// environmentVariableEndpointResolver implements endpoints.ResolverFunc by
+// reading an environment variable corresponding to the service and region.
+// This is how aws-sdk-go supports custom endpoints:
+// https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/
+func environmentVariableEndpointResolver(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+	// e.g., AWS_S3_US_WEST_1_ENDPOINT
+	envVar := fmt.Sprintf("AWS_%s_%s_ENDPOINT", toEnvVar(service), toEnvVar(region))
+	if e := os.Getenv(envVar); e != "" {
+		return endpoints.ResolvedEndpoint{
+			URL: e,
+		}, nil
+	}
+
+	return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
+}
+
+var endpointResolver endpoints.Resolver = endpoints.ResolverFunc(environmentVariableEndpointResolver)

--- a/logger/analytics/endpointresolver_test.go
+++ b/logger/analytics/endpointresolver_test.go
@@ -1,0 +1,54 @@
+package analytics
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_environmentVariableEndpointResolver(t *testing.T) {
+	type args struct {
+		service string
+		region  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+		setEnv  map[string]string
+	}{
+		{
+			name:    "default endpoint",
+			args:    args{service: "firehose", region: "us-west-2"},
+			want:    "https://firehose.us-west-2.amazonaws.com",
+			wantErr: false,
+		},
+		{
+			name:    "override",
+			args:    args{service: "firehose", region: "us-west-2"},
+			want:    "https://vpce-0123456789abcdefg-hijklmno.firehose.us-west-2.vpce.amazonaws.com",
+			wantErr: false,
+			setEnv: map[string]string{
+				"AWS_FIREHOSE_US_WEST_2_ENDPOINT": "https://vpce-0123456789abcdefg-hijklmno.firehose.us-west-2.vpce.amazonaws.com",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv != nil {
+				for k, v := range tt.setEnv {
+					os.Setenv(k, v)
+					defer os.Unsetenv(k)
+				}
+			}
+			got, err := environmentVariableEndpointResolver(tt.args.service, tt.args.region)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("environmentVariableEndpointResolver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.URL != tt.want {
+				t.Errorf("environmentVariableEndpointResolver() = '%s', want '%s'", got.URL, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a custom endpoint resolver:
https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/

The resolver looks for an environment variable like
AWS_FIREHOSE_US_WEST_1_ENDPOINT and uses that URL instead of the
default.

This will let us inject this environment variable during deploys
instead of having to configure every app individually.

