### PR TITLE
Logger Timer

### DIFF
--- a/logger/kayvee_logger.go
+++ b/logger/kayvee_logger.go
@@ -96,6 +96,12 @@ type KayveeLogger interface {
 	// InfoD takes a string and data map. It logs with LogLevel = Info
 	InfoD(title string, data map[string]interface{})
 
+	// Timer takes a string and logs with LogLevel = Debug
+	Timer(tittle string) *Timer
+
+	// TimerD takes a string and data map. It logs with LogLevel = Debug
+	TimerD(tittle string, data map[string]interface{}) *Timer
+
 	// Warn takes a string and logs with LogLevel = Warning
 	Warn(title string)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -112,6 +112,19 @@ const (
 	otlMetrics
 )
 
+// Timer is a helper structure used in logger.Timer method
+type Timer struct {
+	Logger    *Logger
+	StartedAt time.Time
+	Title     string
+}
+
+// Stop is a helper function used in logger.Timer method
+func (t *Timer) Stop() {
+	elapsedTimeSeconds := time.Now().Sub(t.StartedAt).Seconds()
+	t.Logger.DebugD(t.Title+"-end", M{"elapsedTimeSeconds": elapsedTimeSeconds})
+}
+
 /////////////////////////////
 //
 //	Logger
@@ -325,6 +338,19 @@ func (l *Logger) GaugeIntD(title string, value int, data map[string]interface{})
 // Logs with type = gauge, and value = value
 func (l *Logger) GaugeFloatD(title string, value float64, data map[string]interface{}) {
 	l.gauge(title, value, data)
+}
+
+// Timer implements the method for the KayveeLogger interface.
+// Returns Timer structure with .Stop method
+func (l *Logger) Timer(title string) *Timer {
+	return l.TimerD(title, M{})
+}
+
+// TimerD implements the method for the KayveeLogger interface.
+// Returns Timer structure with .Stop method
+func (l *Logger) TimerD(title string, data map[string]interface{}) *Timer {
+	l.DebugD(title+"-start", data)
+	return &Timer{Logger: l, StartedAt: time.Now(), Title: title}
 }
 
 func (l *Logger) gauge(title string, value interface{}, data map[string]interface{}) {

--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -183,6 +183,12 @@ func (ml *MockRouteCountLogger) GaugeFloat(title string, value float64) {
 	ml.logger.GaugeFloat(title, value)
 }
 
+// Timer implements the method for the KayveeLogger interface.
+// Returns Timer structure with .Stop method
+func (ml *MockRouteCountLogger) Timer(title string) *Timer {
+	return ml.logger.Timer(title)
+}
+
 // TraceD implements the method for the KayveeLogger interface.
 func (ml *MockRouteCountLogger) TraceD(title string, data map[string]interface{}) {
 	ml.logger.TraceD(title, data)
@@ -227,4 +233,10 @@ func (ml *MockRouteCountLogger) GaugeIntD(title string, value int, data map[stri
 // Logs with type = gauge, and value = value
 func (ml *MockRouteCountLogger) GaugeFloatD(title string, value float64, data map[string]interface{}) {
 	ml.logger.GaugeFloatD(title, value, data)
+}
+
+// TimerD implements the method for the KayveeLogger interface.
+// Returns Timer structure with .Stop method
+func (ml *MockRouteCountLogger) TimerD(title string, data map[string]interface{}) *Timer {
+	return ml.logger.TimerD(title, data)
 }


### PR DESCRIPTION
**Overview:**
Add Timer and TimerD methods for debugging and logging functions time durations.

Motivation: 
In SHAPI-245 we want to profile some functions, make some changes and see how these changes impact functions' run time.

Usage:
```go
func doWork() {
    defer lg.Timer("doWork").Stop()
    // ...
}
```
This code will generate two log messages
```
Mon <time > {
        source.title=doWork-start
        ...
}
Mon <time> {
        source.title=mpt-metadata.doWork-end
        elapsedTimeSeconds:0.24681975
        ...
}
```

**Pre-merge:**
- [ ] Before merging to `master`, make sure that a new version hasn't been
  merged. Then, use `make bump-major`, `make bump-minor`, or `make bump-patch`
  to bump the version number in VERSION and version.go.

**Post-merge:**
- [ ] After merging to `master`, Use `make tag-version` to set the version
  number in a git tag. Then, run `git push --tags` to push the new tag.
