### PR TITLE
Allow handler to silence logger

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -61,6 +61,10 @@ func (l *logHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		"via":              "kayvee-middleware",
 	})
 
+	if silent, ok := data["silent"].(bool); ok && silent {
+		return
+	}
+
 	// check if the user has opted in to rolling up middleware logs
 	if globalRollupRouter != nil && globalRollupRouter.ShouldRollup(data) {
 		globalRollupRouter.Process(data)


### PR DESCRIPTION
**Overview:**

If you are interested, this allows an handler to silence a logger.
Useful to avoid health checks polluting your logs.