### PR TITLE
Add support for deleting context values and naming Go contexts

### DIFF
--- a/logger/context.go
+++ b/logger/context.go
@@ -1,10 +1,18 @@
 package logger
 
-import "context"
+import (
+	"context"
+)
 
 type loggerKeyType struct{}
 
 var loggerKey = loggerKeyType{}
+
+type contextNameKey string
+
+// A special context key for which the value will be automatically injected into
+// the logger context when a logger is accessed with FromContext.
+const ContextName contextNameKey = "logger.contextname"
 
 // NewContext creates a new context object containing a logger value.
 func NewContext(ctx context.Context, logger KayveeLogger) context.Context {
@@ -17,10 +25,23 @@ func NewContext(ctx context.Context, logger KayveeLogger) context.Context {
 // immediately, e.g.
 //
 //	logger.FromContext(ctx).Info("...")
+//
+// When used with a context that has ContextNameKey set, will automatically
+// include this value in the logger context as context_name.
 func FromContext(ctx context.Context) KayveeLogger {
-	logger := ctx.Value(loggerKey)
-	if lggr, ok := logger.(KayveeLogger); ok {
-		return lggr
+	value := ctx.Value(loggerKey)
+
+	var logger *Logger
+	var ok bool
+	if logger, ok = value.(*Logger); !ok {
+		logger = NewConcreteLogger("")
 	}
-	return New("")
+
+	if name, ok := ctx.Value(ContextName).(string); ok && name != "" {
+		logger.globalsL.Lock()
+		defer logger.globalsL.Unlock()
+		logger.globals["context_name"] = name
+	}
+
+	return logger
 }

--- a/logger/context_test.go
+++ b/logger/context_test.go
@@ -1,10 +1,13 @@
 package logger
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
+	"github.com/Clever/kayvee-go/v7"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFromContext(t *testing.T) {
@@ -16,4 +19,33 @@ func TestFromContext(t *testing.T) {
 	ctx = NewContext(ctx, logger)
 	loggerFromContext := FromContext(ctx)
 	assert.Equal(t, logger, loggerFromContext, "Logger retrieved from context should be the same one we placed in the context")
+}
+
+func TestFromContextWithName(t *testing.T) {
+	r := require.New(t)
+
+	buf := &bytes.Buffer{}
+	logger := New("logger-from-context")
+	logger.SetOutput(buf)
+	ctx := context.WithValue(context.Background(), ContextName, "some-unit-of-work")
+	ctx = NewContext(ctx, logger)
+
+	loggerFromContext := FromContext(ctx)
+	r.Equal(
+		logger,
+		loggerFromContext,
+		"Logger retrieved from context should be the same one we placed in the context",
+	)
+
+	logger.Info("something happened")
+	assertLogFormatAndCompareContent(
+		t,
+		buf.String(),
+		kayvee.FormatLog(
+			"logger-from-context",
+			kayvee.Info,
+			"something happened",
+			M{"context_name": "some-unit-of-work"},
+		),
+	)
 }

--- a/logger/kayvee_logger.go
+++ b/logger/kayvee_logger.go
@@ -25,6 +25,10 @@ type KayveeLogger interface {
 	// GetContext reads a key-val from the global map of data that will be logged with all log messages.
 	GetContext(key string) (interface{}, bool)
 
+	// DeleteContext removes a key from context so that keys can be added on a temporary basis (for
+	// example, within a function) without using different logger instances.
+	DeleteContext(key string)
+
 	// SetConfig allows configuration changes in one go
 	SetConfig(source string, logLvl LogLevel, formatter Formatter, output io.Writer)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -161,6 +161,13 @@ func (l *Logger) GetContext(key string) (interface{}, bool) {
 	return val, ok
 }
 
+func (l *Logger) DeleteContext(key string) {
+	l.globalsL.Lock()
+	defer l.globalsL.Unlock()
+
+	delete(l.globals, key)
+}
+
 // SetRouter implements the method for the KayveeLogger interface.
 func (l *Logger) SetRouter(router router.Router) {
 	l.logRouter = router

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -106,12 +106,13 @@ type Logger struct {
 var globalRouter router.Router
 
 var reservedKeyNames = map[string]bool{
-	"title":   true,
-	"source":  true,
-	"value":   true,
-	"type":    true,
-	"level":   true,
-	"_kvmeta": true,
+	"title":        true,
+	"source":       true,
+	"value":        true,
+	"type":         true,
+	"level":        true,
+	"_kvmeta":      true,
+	"context_name": true,
 }
 
 // SetGlobalRouting installs a new log router onto the KayveeLogger with the

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -291,3 +291,44 @@ func (m *MockRouter) Route(msg map[string]interface{}) map[string]interface{} {
 func TestLoggerImplementsKayveeLogger(t *testing.T) {
 	assert.Implements(t, (*KayveeLogger)(nil), &Logger{}, "*Logger should implement KayveeLogger")
 }
+
+func TestLoggerDeleteContext(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New("logger-tester")
+	logger.SetOutput(buf)
+	logger.AddContext("do", "doe, a deer, a female deer")
+	logger.AddContext("re", "ray, a drop of golden sun")
+	logger.AddContext("mi", "me, a name I call myself")
+	logger.Info("1")
+	assertLogFormatAndCompareContent(
+		t,
+		buf.String(),
+		kv.FormatLog(
+			"logger-tester",
+			kv.Info,
+			"1",
+			M{
+				"do": "doe, a deer, a female deer",
+				"re": "ray, a drop of golden sun",
+				"mi": "me, a name I call myself",
+			},
+		),
+	)
+
+	buf.Reset()
+	logger.DeleteContext("do")
+	logger.Info("2")
+	assertLogFormatAndCompareContent(
+		t,
+		buf.String(),
+		kv.FormatLog(
+			"logger-tester",
+			kv.Info,
+			"2",
+			M{
+				"re": "ray, a drop of golden sun",
+				"mi": "me, a name I call myself",
+			},
+		),
+	)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -11,6 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	os.Setenv("_DEPLOY_ENV", "testing")
+	os.Setenv("_EXECUTION_NAME", "abc123")
+}
 
 // takes two strings (which are assumed to be JSON)
 func compareJSONStrings(t *testing.T, expected string, actual string) {

--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -113,6 +113,11 @@ func (ml *MockRouteCountLogger) GetContext(key string) (interface{}, bool) {
 	return ml.logger.GetContext(key)
 }
 
+// DeleteContext implements the method for the KayveeLogger interface
+func (ml *MockRouteCountLogger) DeleteContext(key string) {
+	ml.logger.DeleteContext(key)
+}
+
 // SetLogLevel implements the method for the KayveeLogger interface.
 func (ml *MockRouteCountLogger) SetLogLevel(logLvl LogLevel) {
 	ml.logger.SetLogLevel(logLvl)


### PR DESCRIPTION
## Clever Coding Standards Agreement

- [X] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## JIRA
[ASOC-699](https://clever.atlassian.net/browse/ASOC-699)

## Overview

- Support deleting context keys from Logger
- Add a defined context_name property to FromContext

### DeleteContext

When logging with a shared Logger instance (either because it is shared via the context with FromContext or because it has been injected through a construct like Controller, Worker, Handler, etc), there may be cases where a context value is useful but then becomes no longer relevant. For example, in edlink-ingestion-worker, I added context within a paging loop but could not fully remove those values, instead [only setting them to the empty string](https://github.com/Clever/edlink-ingestion-worker/blob/48695fee30c2118bd6c3953dd383f620a1886f03/cmd/handler/sync.go#L137-L142).

This change expands the API to remove unused keys so that such keys can be added through context, instead of on individual log lines, while also not persisting the empty values after the keys are no longer relevant.

### context_name key

Adds a special context key `ContextName` for Go contexts that will auto-inject its (string) value into the logger context as `context_name` in `FromContext`. Intended to be used with `context.Value()` so that, when creating or accessing a logger from context, we can add logging tied to that Go context so that we can query logs by Go context with a reserved key.

## Testing

Unit tests. Will apply in edlink-ingestion-worker.

## Rollout

Not really any risks, purely adding new features

## Rollback

n/a

[ASOC-699]: https://clever.atlassian.net/browse/ASOC-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ